### PR TITLE
Refactor CLI config and app parsing logic

### DIFF
--- a/docs/execplans/2-5-1a-operator-cli-contract.md
+++ b/docs/execplans/2-5-1a-operator-cli-contract.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -136,15 +136,18 @@ observable when:
 - [x] 2026-03-13 Inspected `pyproject.toml`, `scripts/local_k8s.py`, the
   existing local-k8s CLI tests, and the earlier Step 2.5 draft ExecPlan.
 - [x] 2026-03-13 Drafted this Task 2.5.a ExecPlan.
-- [ ] Add failing unit tests for the packaged CLI app, command tree, shared
-  root options, config precedence, control-plane client wiring, and runtime
-  adapter selection.
-- [ ] Add failing `pytest-bdd` scenarios for the operator-visible grammar and
-  validation rules.
-- [ ] Implement the packaged CLI scaffold under `ghillie/cli/` and expose it
-  as the `ghillie` console entry point.
-- [ ] Update the CLI spec, users' guide, design document, and roadmap entry.
-- [ ] Run all quality gates and capture concise evidence in this plan.
+- [x] 2026-03-14 Added failing unit tests for the packaged CLI app, command
+  tree, shared root options, config precedence, control-plane client wiring,
+  and runtime adapter selection. The red phase failed with
+  `ModuleNotFoundError: No module named 'ghillie.cli'`.
+- [x] 2026-03-14 Added failing `pytest-bdd` scenarios for the
+  operator-visible grammar and validation rules. The red phase failed with the
+  same missing-package error before implementation.
+- [x] 2026-03-14 Implemented the packaged CLI scaffold under `ghillie/cli/`
+  and exposed it as the `ghillie` console entry point in `pyproject.toml`.
+- [x] 2026-03-14 Updated the CLI spec, users' guide, design document, and
+  roadmap entry to match the scaffold.
+- [x] 2026-03-14 Ran all quality gates and captured the final evidence below.
 
 ## Surprises & Discoveries
 
@@ -168,6 +171,15 @@ observable when:
   multi-repository project can produce a complete project evidence bundle from
   catalogue and repository data", does not match Task 2.5.a and should be
   treated as out of scope unless the roadmap itself is changed.
+- Cyclopts `2.9.x` evaluates function annotations at import time via
+  `inspect.signature(..., eval_str=True)`. That means command modules cannot
+  hide runtime annotation imports such as `Path` behind `TYPE_CHECKING` guards
+  without breaking app import and help rendering.
+- The installed Cyclopts version does not expose newer root-dispatch hooks
+  that would make shared option propagation trivial. The scaffold therefore
+  uses a small explicit pre-parser at the app boundary to collect root-global
+  options before dispatching to the noun tree. This preserves the documented
+  contract while keeping handlers thin and testable.
 
 ## Decision Log
 
@@ -492,10 +504,56 @@ Error: invalid value for --backend
 
 ## Outcomes & Retrospective
 
-This section remains incomplete until Task 2.5.a is implemented.
+Task 2.5.a is implemented.
 
-The intended outcome is a repo-owned, packaged CLI scaffold that makes the
-documented operator contract executable and testable without overreaching into
-the later Step 2.5 tasks. A successful implementation leaves the grammar
-stable, the adapter boundaries explicit, the documentation aligned, and the
-repository ready for Task 2.5.b through Task 2.5.e.
+The repo now carries a packaged operator CLI scaffold under `ghillie/cli/` with
+a console entry point named `ghillie`. The root app exposes the six documented
+nouns, accepts shared configuration once at the root, resolves that
+configuration into one typed context object, constructs a real `httpx`
+control-plane client wrapper, and selects a local runtime adapter named
+`cuprum` or `python-api`.
+
+The command handlers intentionally remain deterministic placeholders for later
+Step 2.5 tasks. Valid invocations return a stable
+`not implemented in Task 2.5.a` status through a shared output policy, while
+invalid options fail during parsing.
+
+Operator-visible evidence captured during implementation:
+
+```plaintext
+$ uv run ghillie --help
+... stack ...
+... estate ...
+... ingest ...
+... export ...
+... report ...
+... metrics ...
+
+$ uv run ghillie --api-base-url http://127.0.0.1:9999 report run --help
+Usage: ghillie report run [OPTIONS]
+
+$ uv run ghillie stack up --backend invalid
+Error: invalid choice for --backend: "invalid"
+```
+
+Test and gate evidence captured during implementation:
+
+- Targeted red phase:
+  `uv run pytest tests/unit/cli -v` failed with
+  `ModuleNotFoundError: No module named 'ghillie.cli'`.
+- Targeted red phase:
+  `uv run pytest tests/features/steps/test_operator_cli_steps.py -v` failed
+  with the same missing-package error.
+- Targeted green phase: `uv run pytest tests/unit/cli -v` passed with
+  `14 passed`.
+- Targeted green phase:
+  `uv run pytest tests/features/steps/test_operator_cli_steps.py -v` passed
+  with `4 passed`.
+- Full repository gates passed:
+  `make fmt`, `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+  `MDLINT=/root/.bun/bin/markdownlint-cli2 make markdownlint`, and `make nixie`.
+- Final test suite result during the full gate run: `730 passed, 35 skipped`.
+
+This leaves the grammar stable, the adapter boundaries explicit, the
+documentation aligned, and the repository ready for the follow-on Task 2.5 work
+without dragging later runtime behaviour into this entry task.

--- a/docs/execplans/2-5-1a-operator-cli-contract.md
+++ b/docs/execplans/2-5-1a-operator-cli-contract.md
@@ -1,0 +1,501 @@
+# Define and scaffold the operator CLI contract
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Task 2.5.a is the entry task for Step 2.5 in `docs/roadmap.md`. Its job is to
+turn the already-documented MVP operator contract into a runnable, testable
+scaffold. After this task is implemented, a human operator will be able to run
+one packaged `ghillie` command, inspect the full noun/verb tree, pass shared
+control-plane options once at the root, and exercise validated option parsing
+without relying on ad hoc scripts.
+
+The deliverable is a scaffold, not a completed control plane. It must make the
+operator grammar stable for the follow-on tasks that add real estate,
+ingestion, reporting, export, and local runtime behaviours. Success is
+observable when:
+
+1. `uv run ghillie --help` lists the top-level nouns `stack`, `estate`,
+   `ingest`, `export`, `report`, and `metrics`.
+2. `uv run ghillie <noun> <verb> --help` works for the verbs documented in
+   `docs/mvp-cli-specification.md`.
+3. Shared root options such as `--api-base-url`, `--auth-token`, `--output`,
+   and `--request-timeout-s` parse once and reach command handlers through one
+   resolved context object.
+4. The scaffold can build an `httpx` control-plane client and select a local
+   runtime adapter named `cuprum` or `python-api`.
+5. Unit tests and `pytest-bdd` scenarios fail before implementation and pass
+   afterwards.
+6. `docs/mvp-cli-specification.md`, `docs/users-guide.md`,
+   `docs/ghillie-design.md`, and `docs/roadmap.md` are updated to match the
+   implemented scaffold exactly.
+
+## Constraints
+
+- Treat `docs/mvp-cli-specification.md` as the contract source of truth for
+  noun-first grammar, root nouns, documented verbs, shared options, config
+  precedence, persisted state, and backend names.
+- Keep the grammar `ghillie <noun> <verb> ...`. Do not introduce a second
+  top-level grammar or preserve `scripts/local_k8s.py` as the primary operator
+  entry point.
+- Follow a hexagonal boundary from the start. The CLI is a driving adapter.
+  The `httpx` control-plane client and local runtime adapters are driven
+  adapters. Command handlers must stay thin and must not embed HTTP or local
+  orchestration details directly.
+- Deliver the scaffold inside the `ghillie/` package with a proper console
+  entry point in `pyproject.toml`. Do not solve Task 2.5.a with another
+  standalone script.
+- Do not break the existing `scripts/local_k8s.py` workflow during this task.
+  It remains a reference implementation and can coexist until later tasks move
+  more operator behaviour into the packaged CLI.
+- Do not silently pull Task 2.5.b, 2.5.c, 2.5.d, or 2.5.e into this change.
+  The scaffold may expose commands for those later tasks, but it must not
+  require their full backend behaviour to satisfy completion.
+- Follow the repository TDD policy. New unit tests and behavioural tests must
+  be written first, demonstrated failing, and then turned green by the
+  implementation.
+- The final implementation must pass `make check-fmt`, `make typecheck`,
+  `make lint`, `make test`, `make markdownlint`, and `make nixie`.
+- Keep Markdown wrapped and lint-clean under
+  `docs/documentation-style-guide.md`.
+
+## Tolerances
+
+- Scope: if Task 2.5.a grows beyond roughly 16 to 20 files or requires
+  substantial changes outside the CLI, documentation, and tests, stop and
+  reassess whether later Step 2.5 work is being pulled in too early.
+- Dependencies: if implementing real `cuprum` execution requires a new runtime
+  dependency or a rename from the currently documented spelling, stop and
+  resolve that contract question before continuing.
+- Behaviour: if a command needs real Docker, Helm, Kubernetes, or live HTTP
+  side effects merely to validate parsing and scaffolding, stop and redesign
+  the seam so tests stay deterministic.
+- Packaging: if the packaged CLI cannot run without importing from
+  `scripts/`, stop and extract or defer that coupling explicitly rather than
+  hiding it inside the scaffold.
+- Interface: if Cyclopts cannot support root-scoped global options in a way
+  that matches the spec and help output, stop and update the spec before
+  implementation.
+- Ambiguity: if the stray completion criterion about producing a
+  multi-repository project evidence bundle is intended to be in scope for this
+  task, stop and clarify it. That criterion belongs to project evidence work,
+  not the CLI scaffold described in Task 2.5.a.
+
+## Risks
+
+- Risk: the repo already has an older broad Step 2.5 draft in
+  `docs/execplans/2-5-1-operator-cli-contract.md`, and its implementation
+  suggestions include a package path that would clash with the existing
+  `ghillie/runtime.py` module. Mitigation: this plan keeps the new scaffold
+  under `ghillie/cli/` and avoids proposing a conflicting `ghillie.runtime.*`
+  package.
+
+- Risk: `docs/mvp-cli-specification.md` and `docs/roadmap.md` both use the
+  backend name `cuprum`, but the repo's existing scripting guidance and
+  dependencies are centred on `plumbum`. Mitigation: preserve `cuprum` as the
+  user-visible selector for Task 2.5.a, treat it as an adapter label rather
+  than a concrete dependency, and record any future rename decision explicitly
+  in the design docs.
+
+- Risk: `pyproject.toml` currently carries `cyclopts` only in the development
+  dependency group, so the packaged CLI could be accidentally non-runnable in a
+  non-dev installation. Mitigation: promote the CLI's true runtime dependencies
+  into `[project.dependencies]` as part of implementation, and cover the
+  console entry point with tests.
+
+- Risk: the current local runtime logic lives under `scripts/local_k8s/`, which
+  is suitable for scripts but not yet a clean packaged adapter boundary.
+  Mitigation: Task 2.5.a should validate adapter selection without depending on
+  full runtime execution. Any extraction of reusable orchestration logic should
+  be minimal and only done if required to keep the packaged CLI clean.
+
+- Risk: behavioural tests for a CLI can become brittle if they shell out to a
+  live environment. Mitigation: keep `pytest-bdd` scenarios black-box at the
+  parsing/help layer and use pure-Python doubles for config resolution, client
+  construction, and adapter selection.
+
+## Progress
+
+- [x] 2026-03-13 Read `AGENTS.md`, the `execplans` skill, and the
+  `hexagonal-architecture` skill.
+- [x] 2026-03-13 Queried project notes for architecture, tooling, gotchas, and
+  prior Step 2.5 decisions.
+- [x] 2026-03-13 Read `docs/roadmap.md`,
+  `docs/mvp-cli-specification.md`, `docs/ghillie-design.md`,
+  `docs/ghillie-proposal.md`,
+  `docs/ghillie-bronze-silver-architecture-design.md`,
+  `docs/async-sqlalchemy-with-pg-and-falcon.md`,
+  `docs/testing-async-falcon-endpoints.md`, and
+  `docs/testing-sqlalchemy-with-pytest-and-py-pglite.md`.
+- [x] 2026-03-13 Inspected `pyproject.toml`, `scripts/local_k8s.py`, the
+  existing local-k8s CLI tests, and the earlier Step 2.5 draft ExecPlan.
+- [x] 2026-03-13 Drafted this Task 2.5.a ExecPlan.
+- [ ] Add failing unit tests for the packaged CLI app, command tree, shared
+  root options, config precedence, control-plane client wiring, and runtime
+  adapter selection.
+- [ ] Add failing `pytest-bdd` scenarios for the operator-visible grammar and
+  validation rules.
+- [ ] Implement the packaged CLI scaffold under `ghillie/cli/` and expose it
+  as the `ghillie` console entry point.
+- [ ] Update the CLI spec, users' guide, design document, and roadmap entry.
+- [ ] Run all quality gates and capture concise evidence in this plan.
+
+## Surprises & Discoveries
+
+- `docs/mvp-cli-specification.md` already captures most of the contract needed
+  for Task 2.5.a, including the noun-first grammar, root nouns, config
+  precedence, state persistence, and backend names. The main work is to make
+  that contract executable and testable.
+- The repo already contains a small Cyclopts reference in
+  `scripts/local_k8s.py` and structure tests in
+  `scripts/tests/test_local_k8s_cli.py`. Those files are the closest local
+  precedent for command registration and CLI test style.
+- There is no packaged `ghillie` console entry point today.
+  `pyproject.toml` has no `[project.scripts]` section for the operator CLI.
+- `httpx` is already a runtime dependency, which lowers the cost of adding a
+  control-plane client. `cyclopts` is not yet a runtime dependency.
+- The broad Step 2.5 draft in
+  `docs/execplans/2-5-1-operator-cli-contract.md` is directionally useful, but
+  one of its suggested package moves would conflict with the existing
+  `ghillie/runtime.py` module. This plan avoids that mistake.
+- The extra completion criterion supplied with this request, "At least one
+  multi-repository project can produce a complete project evidence bundle from
+  catalogue and repository data", does not match Task 2.5.a and should be
+  treated as out of scope unless the roadmap itself is changed.
+
+## Decision Log
+
+1. The packaged CLI will live under `ghillie/cli/`, and the console entry point
+   will resolve there.
+
+   Rationale: the roadmap explicitly asks for a single CLI without ad hoc
+   scripts. `ghillie/cli/` is the least surprising place to add a driving
+   adapter without colliding with `ghillie/runtime.py`.
+
+2. Task 2.5.a will scaffold every documented noun and verb, but handlers for
+   later tasks will remain thin placeholders with deterministic behaviour.
+
+   Rationale: the operator grammar must stabilize now, while the actual estate,
+   ingestion, reporting, export, and runtime workflows are split into later
+   roadmap tasks.
+
+3. Backend selection for `cuprum` and `python-api` will be validated as part of
+   the public contract even if only lightweight placeholder adapters exist at
+   this stage.
+
+   Rationale: validated option parsing is part of the completion criteria, and
+   later tasks need the selector to exist before they can attach real runtime
+   behaviour.
+
+4. The scaffold will resolve all global configuration into one typed context
+   object before it reaches noun handlers.
+
+   Rationale: this is the cleanest way to keep Cyclopts parsing, config
+   precedence, `httpx` client construction, and adapter selection testable in
+   isolation.
+
+5. The plan preserves the documented `cuprum` spelling for now.
+
+   Rationale: the roadmap and CLI specification already publish that selector.
+   Renaming it in implementation without a documented decision would create
+   contract drift.
+
+6. Task 2.5.a does not include the project-evidence completion criterion from
+   the user prompt.
+
+   Rationale: that criterion belongs to multi-repository project evidence work
+   and is not part of the roadmap text for Task 2.5.a. The plan calls this out
+   explicitly rather than smuggling unrelated work into the scaffold.
+
+## Context and orientation
+
+The key repository facts a new implementor needs are these.
+
+`docs/roadmap.md` defines Task 2.5.a as the entry task for the operator-facing
+control plane. It requires a noun/verb CLI grammar, shared global options,
+`httpx` control-plane client plumbing, and local runtime adapter selection.
+
+`docs/mvp-cli-specification.md` already describes the desired operator contract
+in detail. It names the shared options, config precedence, persisted state
+files, root command tree, and backend labels. The implementation must follow
+that document and update it only when reality forces a clarifying change.
+
+The current reusable runtime and API surfaces are limited:
+
+- `ghillie/api/app.py` and related API modules expose the current Falcon ASGI
+  application and the on-demand repository report endpoint.
+- `ghillie/runtime.py` is the current server entry point and must not be
+  disturbed by the CLI scaffold.
+- `scripts/local_k8s.py` is a working Cyclopts script for the local preview
+  workflow, backed by modules under `scripts/local_k8s/`. It is a reference for
+  command structure and tests, not the final operator CLI.
+
+The tests already show the repo's preferred patterns:
+
+- unit tests for CLI structure and pure config logic,
+- Falcon endpoint tests at the application boundary, and
+- `pytest-bdd` scenarios with feature files under `tests/features/` and step
+  implementations under `tests/features/steps/`.
+
+The new CLI scaffold should reuse those patterns rather than inventing new ones.
+
+## Implementation plan
+
+## Milestone 1: lock the contract with failing tests
+
+Begin with tests that describe the scaffold, not later business logic.
+
+Create new unit tests under `tests/unit/cli/` for the packaged app and the
+small typed pieces that make it work. A good first cut is:
+
+- `tests/unit/cli/test_app.py`
+- `tests/unit/cli/test_global_options.py`
+- `tests/unit/cli/test_config_resolution.py`
+- `tests/unit/cli/test_control_plane_client.py`
+- `tests/unit/cli/test_runtime_adapter_selection.py`
+
+These tests should assert, before any implementation exists, that:
+
+1. there is a packaged app object named `ghillie`,
+2. the root nouns match the spec exactly,
+3. each noun exposes the documented verbs,
+4. root-global options parse before the noun and end up in one resolved config
+   object,
+5. config precedence is flag, environment, profile file, persisted state, then
+   hard fallback,
+6. the control-plane client builder turns config into `httpx` base URL,
+   timeout, and auth headers correctly, and
+7. runtime adapter selection accepts `cuprum` and `python-api` and rejects any
+   other value.
+
+Add behavioural coverage with `pytest-bdd` using a feature file such as
+`tests/features/operator_cli_contract.feature` and a step module such as
+`tests/features/steps/test_operator_cli_steps.py`.
+
+Keep the scenarios black-box and operator-visible. Cover at least:
+
+1. `ghillie --help` lists the six top-level nouns,
+2. `ghillie stack up --help` exposes the documented backend and wait options,
+3. `ghillie --api-base-url http://127.0.0.1:9999 report run --help` parses
+   successfully, proving that root-global options are accepted before the noun,
+   and
+4. `ghillie stack up --backend invalid` fails fast with a validation error.
+
+Run the targeted tests first and capture the red phase before implementation.
+
+Suggested commands:
+
+```bash
+set -o pipefail
+UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run pytest tests/unit/cli -v 2>&1 | tee /tmp/ghillie-cli-unit-red.log
+```
+
+```bash
+set -o pipefail
+UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run pytest \
+  tests/features/steps/test_operator_cli_steps.py -v 2>&1 | \
+  tee /tmp/ghillie-cli-bdd-red.log
+```
+
+## Milestone 2: build the packaged CLI core
+
+Add a new package rooted at `ghillie/cli/`. Keep it small, explicit, and easy
+to extend.
+
+Create or update these files:
+
+- `ghillie/cli/__init__.py`
+- `ghillie/cli/__main__.py`
+- `ghillie/cli/app.py`
+- `ghillie/cli/context.py`
+- `ghillie/cli/config.py`
+- `ghillie/cli/control_plane.py`
+- `ghillie/cli/runtime.py` or `ghillie/cli/runtime_adapters.py`
+
+Update `pyproject.toml` to expose the console entry point and to carry the CLI
+runtime dependencies under `[project.dependencies]`, not only in the
+development group.
+
+The scaffold should define four stable concepts:
+
+1. `GlobalOptions`, a frozen dataclass for the raw root options parsed by
+   Cyclopts.
+2. `ResolvedCliConfig`, a frozen dataclass for post-precedence values that
+   handlers actually consume.
+3. `ControlPlaneClient`, a small `httpx` wrapper that knows base URL, auth, and
+   timeout.
+4. `LocalRuntimeAdapter`, a port or protocol for stack-facing operations such
+   as `up`, `down`, `status`, and `logs`.
+
+Keep config loading separate from command registration. That separation makes
+config precedence and client construction testable without spinning the full
+command tree.
+
+## Milestone 3: register the noun and verb tree
+
+Implement the root Cyclopts app and one command group per noun:
+
+- `stack`
+- `estate`
+- `ingest`
+- `export`
+- `report`
+- `metrics`
+
+Under each noun, register the verbs listed in `docs/mvp-cli-specification.md`.
+A practical layout is one module per noun:
+
+- `ghillie/cli/commands/stack.py`
+- `ghillie/cli/commands/estate.py`
+- `ghillie/cli/commands/ingest.py`
+- `ghillie/cli/commands/export.py`
+- `ghillie/cli/commands/report.py`
+- `ghillie/cli/commands/metrics.py`
+
+Each handler should do only the minimum needed in Task 2.5.a:
+
+1. resolve the shared CLI context,
+2. build the right client or adapter,
+3. validate the documented options, and
+4. return a deterministic placeholder for behaviours owned by later tasks.
+
+Define the placeholder behaviour explicitly in the docs and tests. The easiest
+contract is:
+
+- `--help` always works,
+- valid command invocations that belong to later tasks return a clear
+  "not implemented in Task 2.5.a" message, and
+- invalid options fail through normal Cyclopts validation.
+
+Do not let placeholder handlers turn into arbitrary `print()` calls. They
+should still route through one output policy so that `--output json` remains
+predictable.
+
+## Milestone 4: wire the driven adapters cleanly
+
+Implement the control-plane client for real. Even if the CLI does not yet call
+many endpoints, the object itself should be functional and tested. It should
+own:
+
+- base URL handling,
+- timeout configuration,
+- bearer-token header injection, and
+- creation and cleanup of the `httpx` client.
+
+Implement runtime adapter selection as a clean seam. For Task 2.5.a the
+selection logic must be real even if execution remains skeletal:
+
+- selecting `python-api` constructs the adapter class intended to host direct
+  Python integrations later,
+- selecting `cuprum` constructs a separate adapter class, which may remain a
+  placeholder until a concrete dependency decision is made, and
+- unknown adapter names fail validation before any side effects occur.
+
+Do not make the packaged CLI depend on imports from `scripts/` just to satisfy
+Task 2.5.a. If a tiny shared helper must move to support clean packaging,
+extract only that helper into `ghillie/cli/` or another non-conflicting package
+inside `ghillie/`. Leave broader local runtime migration for later work.
+
+## Milestone 5: update the contract documents
+
+Update the documents that operators and future implementors will read.
+
+`docs/mvp-cli-specification.md` must reflect the implemented command tree,
+placeholder semantics, and any clarifications to config resolution or help
+behaviour discovered during implementation.
+
+`docs/users-guide.md` must gain an operator CLI section that shows:
+
+- how to inspect the root command tree,
+- how shared configuration is resolved, and
+- what the scaffold can do at Task 2.5.a versus what remains for later tasks.
+
+`docs/ghillie-design.md` must record the architectural decision that the
+operator CLI is a driving adapter with separate control-plane and local-runtime
+driven adapters.
+
+`docs/roadmap.md` must mark Task 2.5.a as done only after the implementation,
+tests, documentation updates, and quality gates all pass.
+
+## Validation and evidence
+
+Use a red-green-refactor loop for the targeted CLI tests, then run the full
+repository gates sequentially. Run the Make targets through `tee` with
+`set -o pipefail` so failures are preserved in the exit code and logs can be
+inspected afterwards.
+
+Suggested verification commands:
+
+```bash
+set -o pipefail
+make fmt 2>&1 | tee /tmp/ghillie-make-fmt.log
+```
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/ghillie-make-check-fmt.log
+```
+
+```bash
+set -o pipefail
+make typecheck 2>&1 | tee /tmp/ghillie-make-typecheck.log
+```
+
+```bash
+set -o pipefail
+make lint 2>&1 | tee /tmp/ghillie-make-lint.log
+```
+
+```bash
+set -o pipefail
+make test 2>&1 | tee /tmp/ghillie-make-test.log
+```
+
+```bash
+set -o pipefail
+MDLINT=/root/.bun/bin/markdownlint-cli2 make markdownlint 2>&1 | tee /tmp/ghillie-make-markdownlint.log
+```
+
+```bash
+set -o pipefail
+make nixie 2>&1 | tee /tmp/ghillie-make-nixie.log
+```
+
+Record concise evidence in this plan once implementation happens. At minimum,
+capture:
+
+- the help output proving the noun tree,
+- one example showing a valid root-global option parse,
+- one example showing invalid backend rejection, and
+- the final gate results.
+
+Expected operator-visible evidence after completion should look roughly like:
+
+```plaintext
+$ uv run ghillie --help
+... stack ...
+... estate ...
+... ingest ...
+... export ...
+... report ...
+... metrics ...
+
+$ uv run ghillie stack up --backend invalid
+Error: invalid value for --backend
+```
+
+## Outcomes & Retrospective
+
+This section remains incomplete until Task 2.5.a is implemented.
+
+The intended outcome is a repo-owned, packaged CLI scaffold that makes the
+documented operator contract executable and testable without overreaching into
+the later Step 2.5 tasks. A successful implementation leaves the grammar
+stable, the adapter boundaries explicit, the documentation aligned, and the
+repository ready for Task 2.5.b through Task 2.5.e.

--- a/docs/ghillie-design.md
+++ b/docs/ghillie-design.md
@@ -124,6 +124,29 @@ scale of modern software estates, which may generate thousands of events per
 minute, the gateway must be designed for high availability and asynchronous
 processing.
 
+### 3.0 Operator CLI scaffold boundary (Task 2.5.a)
+
+The packaged operator CLI is a driving adapter layered alongside the runtime
+server and background workers. Its responsibility in Task 2.5.a is to make the
+MVP control-plane contract executable without pulling estate, ingestion,
+export, metrics, and reporting implementation forward prematurely.
+
+The boundary is intentionally explicit:
+
+- `ghillie/cli/app.py` owns noun-first command registration and root-global
+  option parsing.
+- `ghillie/cli/config.py` resolves shared configuration once per invocation,
+  applying the documented precedence of flag, environment, profile file,
+  persisted state, then fallback URL.
+- `ghillie/cli/control_plane.py` is the driven adapter seam for API-backed
+  commands. It owns `httpx` base URL, timeout, and bearer-token setup.
+- `ghillie/cli/runtime_adapters.py` is the driven adapter seam for local stack
+  integration. Task 2.5.a validates selector names (`cuprum`, `python-api`) and
+  leaves concrete orchestration work to later tasks.
+
+This keeps the CLI thin and prevents command handlers from embedding HTTP or
+local-runtime details directly.
+
 ### 3.1 Webhook Reception and Verification
 
 The primary mechanism for real-time data acquisition is the webhook. Ghillie

--- a/docs/mvp-cli-specification.md
+++ b/docs/mvp-cli-specification.md
@@ -190,6 +190,28 @@ ghillie
     nice
 ```
 
+### Task 2.5.a scaffold status
+
+The first packaged operator CLI delivery is a scaffold, not a finished control
+plane. The implemented Task 2.5.a contract is:
+
+- `uv run ghillie --help` exposes the full root noun tree shown above.
+- Every documented noun and verb is registered under the packaged
+  `ghillie/cli/` entry point, even where later tasks still own the real backend
+  behaviour.
+- Root-global options are resolved before noun dispatch. The scaffold accepts
+  `--api-base-url`, `--auth-token`, `--output`, `--log-level`,
+  `--request-timeout-s`, `--non-interactive` or `--interactive`, and
+  `--dry-run` or `--no-dry-run`.
+- Valid placeholder invocations return deterministic structured output with
+  `status: not_implemented` and the message `not implemented in Task 2.5.a`.
+- Invalid CLI input still fails fast with exit code `2`.
+
+The `stack up` backend selector and the control-plane client seam are real in
+the scaffold: `cuprum` and `python-api` both resolve to distinct local runtime
+adapter placeholders, and API-facing commands resolve one `httpx` client from
+the shared root configuration.
+
 ## Stack commands (k3d/Helm lifecycle)
 
 ### `ghillie stack up`
@@ -510,6 +532,7 @@ Output contract:
 
 - `--output table` for operator readability.
 - `--output json` for automation.
+- `--output yaml` for YAML-oriented operator workflows.
 - Errors should include structured fields: `code`, `message`, and `hint`.
 
 ## Security constraints

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -388,7 +388,7 @@ operationally safe to run.
 **Goal:** Make the full MVP workflow executable through stable HTTP APIs and a
 single `cyclopts` CLI, without ad hoc scripts.
 
-- [ ] **Task 2.5.a – Define and scaffold the operator CLI contract**
+- [x] **Task 2.5.a – Define and scaffold the operator CLI contract**
   Define the command grammar and command groups in
   `docs/mvp-cli-specification.md`, and scaffold a `cyclopts` CLI with the
   following features:
@@ -402,6 +402,14 @@ single `cyclopts` CLI, without ad hoc scripts.
 
   *Completion criteria:* A runnable CLI skeleton exists with the specified root
   command tree and validated option parsing.
+
+  *Implemented:* The packaged `ghillie` console entry point now lives under
+  `ghillie/cli/` and exposes the full MVP noun tree (`stack`, `estate`,
+  `ingest`, `export`, `report`, `metrics`). Task 2.5.a added root-global option
+  parsing and precedence resolution, a reusable `httpx` control-plane client
+  wrapper, runtime adapter selection for `cuprum` and `python-api`, unit tests
+  for the CLI scaffold, and `pytest-bdd` coverage for help output, root option
+  parsing, and invalid backend rejection.
 
 - [ ] **Task 2.5.b – Add estate-management APIs and CLI commands**
   Implement API endpoints and CLI commands for the following estate operations:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1,5 +1,49 @@
 # ghillie Users' Guide
 
+## Operator CLI scaffold (Task 2.5.a)
+
+Ghillie now ships a packaged operator CLI entry point:
+
+```bash
+uv run ghillie --help
+```
+
+The scaffolded root nouns are `stack`, `estate`, `ingest`, `export`, `report`,
+and `metrics`. The CLI grammar is noun-first:
+
+```text
+ghillie <noun> <verb> [selectors] [predicates] [options]
+```
+
+Shared root configuration is resolved before noun dispatch with this precedence:
+
+1. Explicit root CLI flags such as `--api-base-url`.
+2. Environment variables such as `GHILLIE_API_BASE_URL`.
+3. `~/.config/ghillie/cli.toml`.
+4. `~/.config/ghillie/state.json`.
+5. Fallback `http://127.0.0.1:8080`.
+
+Task 2.5.a delivers the command contract, shared config resolution, control
+plane client wiring, and local runtime adapter selection for `cuprum` and
+`python-api`. Most verbs still return deterministic placeholder payloads until
+later roadmap tasks attach the real estate, ingestion, export, metrics, and
+reporting backends.
+
+Two useful checks:
+
+```bash
+uv run ghillie stack up --help
+```
+
+This shows the documented stack scaffold options, including `--backend` and
+`--wait` or `--no-wait`.
+
+```bash
+uv run ghillie --api-base-url http://127.0.0.1:9999 report run --help
+```
+
+This proves the shared root options are accepted before the noun command.
+
 ## Estate catalogue (Phase 1.1)
 
 Ghillie now ships a YAML 1.2 catalogue describing programmes, projects,

--- a/ghillie/cli/__init__.py
+++ b/ghillie/cli/__init__.py
@@ -1,0 +1,7 @@
+"""Packaged operator CLI entry points."""
+
+from __future__ import annotations
+
+from .app import app, main
+
+__all__ = ["app", "main"]

--- a/ghillie/cli/__init__.py
+++ b/ghillie/cli/__init__.py
@@ -1,7 +1,5 @@
 """Packaged operator CLI entry points."""
 
-from __future__ import annotations
-
 from .app import app, main
 
 __all__ = ["app", "main"]

--- a/ghillie/cli/__main__.py
+++ b/ghillie/cli/__main__.py
@@ -1,0 +1,10 @@
+"""Module entry point for `python -m ghillie.cli`."""
+
+from __future__ import annotations
+
+import sys
+
+from .app import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ghillie/cli/__main__.py
+++ b/ghillie/cli/__main__.py
@@ -1,7 +1,5 @@
 """Module entry point for `python -m ghillie.cli`."""
 
-from __future__ import annotations
-
 import sys
 
 from .app import main

--- a/ghillie/cli/app.py
+++ b/ghillie/cli/app.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import sys
-import typing as typ
 
 from cyclopts import App
 from cyclopts.exceptions import CycloptsError
@@ -45,17 +44,19 @@ app.command(report_app)
 app.command(metrics_app)
 
 
-def parse_global_options(  # noqa: C901, PLR0912, PLR0915
+def parse_global_options(
     argv: list[str],
 ) -> tuple[GlobalOptions, list[str]]:
     """Parse root-global options before handing off to the noun command tree."""
-    api_base_url: str | None = None
-    auth_token: str | None = None
-    output: typ.Literal["table", "json", "yaml"] | None = None
-    log_level: typ.Literal["debug", "info", "warn", "error"] | None = None
-    request_timeout_s: float | None = None
-    non_interactive: bool | None = None
-    dry_run: bool | None = None
+    state: dict[str, object] = {
+        "api_base_url": None,
+        "auth_token": None,
+        "output": None,
+        "log_level": None,
+        "request_timeout_s": None,
+        "non_interactive": None,
+        "dry_run": None,
+    }
     remaining: list[str] = []
     index = 0
     while index < len(argv):
@@ -66,19 +67,7 @@ def parse_global_options(  # noqa: C901, PLR0912, PLR0915
             if next_index >= len(argv):
                 msg = f"{token} requires a value"
                 raise ValueError(msg)
-            value = _coerce_root_value(field_name, argv[next_index])
-            if field_name == "api_base_url":
-                api_base_url = typ.cast("str", value)
-            elif field_name == "auth_token":
-                auth_token = typ.cast("str", value)
-            elif field_name == "output":
-                output = typ.cast('typ.Literal["table", "json", "yaml"]', value)
-            elif field_name == "log_level":
-                log_level = typ.cast(
-                    'typ.Literal["debug", "info", "warn", "error"]', value
-                )
-            else:
-                request_timeout_s = typ.cast("float", value)
+            _apply_valued_option(field_name, argv[next_index], state)
             index += 2
             continue
         if option_with_value := _split_option_with_value(token):
@@ -87,27 +76,12 @@ def parse_global_options(  # noqa: C901, PLR0912, PLR0915
             if field_name is None:
                 remaining = argv[index:]
                 break
-            value = _coerce_root_value(field_name, option_value)
-            if field_name == "api_base_url":
-                api_base_url = typ.cast("str", value)
-            elif field_name == "auth_token":
-                auth_token = typ.cast("str", value)
-            elif field_name == "output":
-                output = typ.cast('typ.Literal["table", "json", "yaml"]', value)
-            elif field_name == "log_level":
-                log_level = typ.cast(
-                    'typ.Literal["debug", "info", "warn", "error"]', value
-                )
-            else:
-                request_timeout_s = typ.cast("float", value)
+            _apply_valued_option(field_name, option_value, state)
             index += 1
             continue
         if token in _BOOLEAN_OPTION_VALUES:
             field_name, field_value = _BOOLEAN_OPTION_VALUES[token]
-            if field_name == "non_interactive":
-                non_interactive = field_value
-            else:
-                dry_run = field_value
+            state[field_name] = field_value
             index += 1
             continue
         remaining = argv[index:]
@@ -115,18 +89,7 @@ def parse_global_options(  # noqa: C901, PLR0912, PLR0915
     else:
         remaining = []
 
-    return (
-        GlobalOptions(
-            api_base_url=api_base_url,
-            auth_token=auth_token,
-            output=output,
-            log_level=log_level,
-            request_timeout_s=request_timeout_s,
-            non_interactive=non_interactive,
-            dry_run=dry_run,
-        ),
-        remaining,
-    )
+    return GlobalOptions(**state), remaining  # type: ignore[arg-type]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -169,6 +132,13 @@ def _coerce_root_value(field_name: str, raw_value: str) -> object:
     return raw_value
 
 
+def _apply_valued_option(
+    field_name: str, raw_value: str, state: dict[str, object]
+) -> None:
+    """Coerce *raw_value* and store it in the accumulator *state*."""
+    state[field_name] = _coerce_root_value(field_name, raw_value)
+
+
 def _coerce_result_to_exit_code(result: object) -> int:
     if result is None:
         return 0
@@ -180,9 +150,14 @@ def _coerce_result_to_exit_code(result: object) -> int:
     return 0
 
 
+def _is_invalid_backend_choice(message: str) -> bool:
+    """Return True when the cyclopts error describes an invalid --backend value."""
+    return "--backend" in message and "Literal" in message and "python-api" in message
+
+
 def _format_cyclopts_error(error: CycloptsError) -> str:
     message = str(error)
-    if "--backend" in message and "Literal" in message and "python-api" in message:
+    if _is_invalid_backend_choice(message):
         invalid_value = message.split('"')[1]
         return f'invalid choice for --backend: "{invalid_value}"'
     return message

--- a/ghillie/cli/app.py
+++ b/ghillie/cli/app.py
@@ -169,7 +169,8 @@ def _coerce_result_to_exit_code(result: object) -> int:
     if isinstance(result, str):
         print(result)
         return 0
-    return 0
+    print(f"Unexpected command result: {result!r}", file=sys.stderr)
+    return 1
 
 
 def _is_invalid_backend_choice(message: str) -> bool:

--- a/ghillie/cli/app.py
+++ b/ghillie/cli/app.py
@@ -181,6 +181,8 @@ def _is_invalid_backend_choice(message: str) -> bool:
 def _format_cyclopts_error(error: CycloptsError) -> str:
     message = str(error)
     if _is_invalid_backend_choice(message):
-        invalid_value = message.split('"')[1]
-        return f'invalid choice for --backend: "{invalid_value}"'
+        parts = message.split('"')
+        if len(parts) > 1:
+            invalid_value = parts[1]
+            return f'invalid choice for --backend: "{invalid_value}"'
     return message

--- a/ghillie/cli/app.py
+++ b/ghillie/cli/app.py
@@ -44,6 +44,43 @@ app.command(report_app)
 app.command(metrics_app)
 
 
+def _consume_value_option(
+    token: str, argv: list[str], index: int, state: dict[str, object]
+) -> int:
+    """Handle a ``--flag VALUE`` pair.
+
+    Returns the advanced index (``index + 2``) if matched, or *index* if the
+    token is not a recognised value-bearing option.
+    Raises ``ValueError`` when the flag appears at the end of *argv*.
+    """
+    if token not in _OPTION_REQUIRES_VALUE:
+        return index
+    field_name = _OPTION_REQUIRES_VALUE[token]
+    next_index = index + 1
+    if next_index >= len(argv):
+        msg = f"{token} requires a value"
+        raise ValueError(msg)
+    _apply_valued_option(field_name, argv[next_index], state)
+    return index + 2
+
+
+def _consume_inline_option(token: str, state: dict[str, object]) -> bool:
+    """Handle a ``--flag=VALUE`` token.
+
+    Returns ``True`` if the token was consumed, ``False`` otherwise —
+    including when the flag name is not in ``_OPTION_REQUIRES_VALUE``.
+    """
+    parsed = _split_option_with_value(token)
+    if parsed is None:
+        return False
+    option_name, option_value = parsed
+    field_name = _OPTION_REQUIRES_VALUE.get(option_name)
+    if field_name is None:
+        return False
+    _apply_valued_option(field_name, option_value, state)
+    return True
+
+
 def parse_global_options(
     argv: list[str],
 ) -> tuple[GlobalOptions, list[str]]:
@@ -57,26 +94,14 @@ def parse_global_options(
         "non_interactive": None,
         "dry_run": None,
     }
-    remaining: list[str] = []
     index = 0
     while index < len(argv):
         token = argv[index]
-        if token in _OPTION_REQUIRES_VALUE:
-            field_name = _OPTION_REQUIRES_VALUE[token]
-            next_index = index + 1
-            if next_index >= len(argv):
-                msg = f"{token} requires a value"
-                raise ValueError(msg)
-            _apply_valued_option(field_name, argv[next_index], state)
-            index += 2
+        new_index = _consume_value_option(token, argv, index, state)
+        if new_index != index:
+            index = new_index
             continue
-        if option_with_value := _split_option_with_value(token):
-            option_name, option_value = option_with_value
-            field_name = _OPTION_REQUIRES_VALUE.get(option_name)
-            if field_name is None:
-                remaining = argv[index:]
-                break
-            _apply_valued_option(field_name, option_value, state)
+        if _consume_inline_option(token, state):
             index += 1
             continue
         if token in _BOOLEAN_OPTION_VALUES:
@@ -84,12 +109,9 @@ def parse_global_options(
             state[field_name] = field_value
             index += 1
             continue
-        remaining = argv[index:]
-        break
-    else:
-        remaining = []
+        return GlobalOptions(**state), argv[index:]  # type: ignore[arg-type]
 
-    return GlobalOptions(**state), remaining  # type: ignore[arg-type]
+    return GlobalOptions(**state), []  # type: ignore[arg-type]
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/ghillie/cli/app.py
+++ b/ghillie/cli/app.py
@@ -1,0 +1,188 @@
+"""Root app and entry-point helpers for the packaged operator CLI."""
+
+from __future__ import annotations
+
+import os
+import sys
+import typing as typ
+
+from cyclopts import App
+from cyclopts.exceptions import CycloptsError
+
+from ghillie.cli.commands.estate import estate_app
+from ghillie.cli.commands.export import export_app
+from ghillie.cli.commands.ingest import ingest_app
+from ghillie.cli.commands.metrics import metrics_app
+from ghillie.cli.commands.report import report_app
+from ghillie.cli.commands.stack import stack_app
+from ghillie.cli.config import GlobalOptions, resolve_cli_config
+from ghillie.cli.context import CommandContext, use_context
+
+_OPTION_REQUIRES_VALUE = {
+    "--api-base-url": "api_base_url",
+    "--auth-token": "auth_token",
+    "--output": "output",
+    "--log-level": "log_level",
+    "--request-timeout-s": "request_timeout_s",
+}
+_BOOLEAN_OPTION_VALUES = {
+    "--non-interactive": ("non_interactive", True),
+    "--interactive": ("non_interactive", False),
+    "--dry-run": ("dry_run", True),
+    "--no-dry-run": ("dry_run", False),
+}
+
+app = App(
+    name="ghillie",
+    help="Operator-facing CLI scaffold for the Ghillie MVP control plane.",
+    version="0.1.0",
+)
+app.command(stack_app)
+app.command(estate_app)
+app.command(ingest_app)
+app.command(export_app)
+app.command(report_app)
+app.command(metrics_app)
+
+
+def parse_global_options(  # noqa: C901, PLR0912, PLR0915
+    argv: list[str],
+) -> tuple[GlobalOptions, list[str]]:
+    """Parse root-global options before handing off to the noun command tree."""
+    api_base_url: str | None = None
+    auth_token: str | None = None
+    output: typ.Literal["table", "json", "yaml"] | None = None
+    log_level: typ.Literal["debug", "info", "warn", "error"] | None = None
+    request_timeout_s: float | None = None
+    non_interactive: bool | None = None
+    dry_run: bool | None = None
+    remaining: list[str] = []
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token in _OPTION_REQUIRES_VALUE:
+            field_name = _OPTION_REQUIRES_VALUE[token]
+            next_index = index + 1
+            if next_index >= len(argv):
+                msg = f"{token} requires a value"
+                raise ValueError(msg)
+            value = _coerce_root_value(field_name, argv[next_index])
+            if field_name == "api_base_url":
+                api_base_url = typ.cast("str", value)
+            elif field_name == "auth_token":
+                auth_token = typ.cast("str", value)
+            elif field_name == "output":
+                output = typ.cast('typ.Literal["table", "json", "yaml"]', value)
+            elif field_name == "log_level":
+                log_level = typ.cast(
+                    'typ.Literal["debug", "info", "warn", "error"]', value
+                )
+            else:
+                request_timeout_s = typ.cast("float", value)
+            index += 2
+            continue
+        if option_with_value := _split_option_with_value(token):
+            option_name, option_value = option_with_value
+            field_name = _OPTION_REQUIRES_VALUE.get(option_name)
+            if field_name is None:
+                remaining = argv[index:]
+                break
+            value = _coerce_root_value(field_name, option_value)
+            if field_name == "api_base_url":
+                api_base_url = typ.cast("str", value)
+            elif field_name == "auth_token":
+                auth_token = typ.cast("str", value)
+            elif field_name == "output":
+                output = typ.cast('typ.Literal["table", "json", "yaml"]', value)
+            elif field_name == "log_level":
+                log_level = typ.cast(
+                    'typ.Literal["debug", "info", "warn", "error"]', value
+                )
+            else:
+                request_timeout_s = typ.cast("float", value)
+            index += 1
+            continue
+        if token in _BOOLEAN_OPTION_VALUES:
+            field_name, field_value = _BOOLEAN_OPTION_VALUES[token]
+            if field_name == "non_interactive":
+                non_interactive = field_value
+            else:
+                dry_run = field_value
+            index += 1
+            continue
+        remaining = argv[index:]
+        break
+    else:
+        remaining = []
+
+    return (
+        GlobalOptions(
+            api_base_url=api_base_url,
+            auth_token=auth_token,
+            output=output,
+            log_level=log_level,
+            request_timeout_s=request_timeout_s,
+            non_interactive=non_interactive,
+            dry_run=dry_run,
+        ),
+        remaining,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the packaged CLI."""
+    tokens = list(sys.argv[1:] if argv is None else argv)
+    try:
+        global_options, remaining = parse_global_options(tokens)
+        config = resolve_cli_config(global_options, env=os.environ)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        with use_context(CommandContext(config=config)):
+            result = app(
+                remaining or ["--help"],
+                exit_on_error=False,
+                print_error=False,
+            )
+    except CycloptsError as exc:
+        print(f"Error: {_format_cyclopts_error(exc)}", file=sys.stderr)
+        return 2
+    return _coerce_result_to_exit_code(result)
+
+
+def _split_option_with_value(token: str) -> tuple[str, str] | None:
+    if "=" not in token:
+        return None
+    option_name, option_value = token.split("=", 1)
+    return option_name, option_value
+
+
+def _coerce_root_value(field_name: str, raw_value: str) -> object:
+    if field_name == "request_timeout_s":
+        try:
+            return float(raw_value)
+        except ValueError as exc:
+            msg = "--request-timeout-s must be a float"
+            raise ValueError(msg) from exc
+    return raw_value
+
+
+def _coerce_result_to_exit_code(result: object) -> int:
+    if result is None:
+        return 0
+    if isinstance(result, int):
+        return result
+    if isinstance(result, str):
+        print(result)
+        return 0
+    return 0
+
+
+def _format_cyclopts_error(error: CycloptsError) -> str:
+    message = str(error)
+    if "--backend" in message and "Literal" in message and "python-api" in message:
+        invalid_value = message.split('"')[1]
+        return f'invalid choice for --backend: "{invalid_value}"'
+    return message

--- a/ghillie/cli/app.py
+++ b/ghillie/cli/app.py
@@ -175,7 +175,10 @@ def _coerce_result_to_exit_code(result: object) -> int:
 
 def _is_invalid_backend_choice(message: str) -> bool:
     """Return True when the cyclopts error describes an invalid --backend value."""
-    return "--backend" in message and "Literal" in message and "python-api" in message
+    return "--backend" in message and (
+        ("Literal" in message and "python-api" in message)
+        or "RuntimeBackend" in message
+    )
 
 
 def _format_cyclopts_error(error: CycloptsError) -> str:

--- a/ghillie/cli/app.py
+++ b/ghillie/cli/app.py
@@ -120,7 +120,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         global_options, remaining = parse_global_options(tokens)
         config = resolve_cli_config(global_options, env=os.environ)
-    except ValueError as exc:
+    except (ValueError, TypeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2
 

--- a/ghillie/cli/app.py
+++ b/ghillie/cli/app.py
@@ -109,9 +109,9 @@ def parse_global_options(
             state[field_name] = field_value
             index += 1
             continue
-        return GlobalOptions(**state), argv[index:]  # type: ignore[arg-type]
+        return GlobalOptions(**state), argv[index:]  # type: ignore[arg-type]  # safe: state values are validated/normalized to match GlobalOptions fields, argv[index:] is List[str]
 
-    return GlobalOptions(**state), []  # type: ignore[arg-type]
+    return GlobalOptions(**state), []  # type: ignore[arg-type]  # safe: state values are validated/normalized to match GlobalOptions fields
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/ghillie/cli/commands/__init__.py
+++ b/ghillie/cli/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Command registration for the packaged operator CLI."""

--- a/ghillie/cli/commands/estate.py
+++ b/ghillie/cli/commands/estate.py
@@ -1,0 +1,106 @@
+"""Estate noun commands for the packaged operator CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+
+from cyclopts import App
+
+from ghillie.cli.context import get_current_context
+from ghillie.cli.control_plane import ControlPlaneClient
+from ghillie.cli.output import render_output
+
+estate_app = App(name="estate", help="Manage estate configuration operations.")
+repo_app = App(name="repo", help="Manage estate repository configuration.")
+
+
+def _api_placeholder(noun: str, verb: str, **fields: object) -> str:
+    context = get_current_context()
+    with ControlPlaneClient(context.config):
+        return render_output(
+            {
+                "noun": noun,
+                "verb": verb,
+                "status": "not_implemented",
+                "message": "not implemented in Task 2.5.a",
+                **fields,
+            },
+            output=context.config.output,
+        )
+
+
+@estate_app.command(name="import")
+def import_catalogue(
+    *,
+    estate_key: str,
+    catalogue_path: Path,
+    commit_sha: str,
+    estate_name: str | None = None,
+) -> str:
+    """Import catalogue definitions into estate storage."""
+    return _api_placeholder(
+        "estate",
+        "import",
+        estate_key=estate_key,
+        catalogue_path=str(catalogue_path),
+        commit_sha=commit_sha,
+        estate_name=estate_name or "",
+    )
+
+
+@estate_app.command
+def sync(*, estate_key: str, wait: bool = True) -> str:
+    """Sync imported catalogue repositories into the registry."""
+    return _api_placeholder("estate", "sync", estate_key=estate_key, wait=wait)
+
+
+@estate_app.command(name="list")
+def list_estates(*, active: bool = True, inactive: bool = False) -> str:
+    """List estates known to the control plane."""
+    return _api_placeholder(
+        "estate",
+        "list",
+        active=active,
+        inactive=inactive,
+    )
+
+
+@repo_app.command(name="list")
+def list_repositories(  # noqa: PLR0913
+    *,
+    estate_key: str,
+    active: bool = True,
+    inactive: bool = False,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """List repositories for one estate."""
+    return _api_placeholder(
+        "estate repo",
+        "list",
+        estate_key=estate_key,
+        active=active,
+        inactive=inactive,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@repo_app.command(name="set")
+def set_repository(
+    *,
+    owner: str,
+    name: str,
+    ingestion_enabled: bool,
+) -> str:
+    """Set per-repository ingestion state."""
+    return _api_placeholder(
+        "estate repo",
+        "set",
+        owner=owner,
+        name=name,
+        ingestion_enabled=ingestion_enabled,
+    )
+
+
+estate_app.command(repo_app)

--- a/ghillie/cli/commands/estate.py
+++ b/ghillie/cli/commands/estate.py
@@ -66,6 +66,8 @@ def list_estates(*, active: bool = True, inactive: bool = False) -> str:
     )
 
 
+# @codescene(disable:"Excess Number of Function Arguments")
+# 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @repo_app.command(name="list")
 def list_repositories(  # noqa: PLR0913
     *,

--- a/ghillie/cli/commands/estate.py
+++ b/ghillie/cli/commands/estate.py
@@ -6,6 +6,7 @@ from pathlib import Path  # noqa: TC003
 
 from cyclopts import App
 
+from ghillie.cli.commands.params import PaginationFilter
 from ghillie.cli.context import get_current_context
 from ghillie.cli.control_plane import ControlPlaneClient
 from ghillie.cli.output import render_output
@@ -75,14 +76,17 @@ def list_repositories(  # noqa: PLR0913
     offset: int = 0,
 ) -> str:
     """List repositories for one estate."""
+    pagination = PaginationFilter(
+        active=active, inactive=inactive, limit=limit, offset=offset
+    )
     return _api_placeholder(
         "estate repo",
         "list",
         estate_key=estate_key,
-        active=active,
-        inactive=inactive,
-        limit=limit,
-        offset=offset,
+        active=pagination.active,
+        inactive=pagination.inactive,
+        limit=pagination.limit,
+        offset=pagination.offset,
     )
 
 

--- a/ghillie/cli/commands/estate.py
+++ b/ghillie/cli/commands/estate.py
@@ -6,7 +6,6 @@ from pathlib import Path  # noqa: TC003
 
 from cyclopts import App
 
-from ghillie.cli.commands.params import PaginationFilter
 from ghillie.cli.context import get_current_context
 from ghillie.cli.control_plane import ControlPlaneClient
 from ghillie.cli.output import render_output
@@ -78,17 +77,14 @@ def list_repositories(  # noqa: PLR0913
     offset: int = 0,
 ) -> str:
     """List repositories for one estate."""
-    pagination = PaginationFilter(
-        active=active, inactive=inactive, limit=limit, offset=offset
-    )
     return _api_placeholder(
         "estate repo",
         "list",
         estate_key=estate_key,
-        active=pagination.active,
-        inactive=pagination.inactive,
-        limit=pagination.limit,
-        offset=pagination.offset,
+        active=active,
+        inactive=inactive,
+        limit=limit,
+        offset=offset,
     )
 
 

--- a/ghillie/cli/commands/export.py
+++ b/ghillie/cli/commands/export.py
@@ -71,6 +71,8 @@ def events(
     return _export_command("events", target=target, window=window, sink=sink)
 
 
+# @codescene(disable:"Excess Number of Function Arguments")
+# 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @export_app.command
 def evidence(  # noqa: PLR0913
     *,
@@ -106,6 +108,8 @@ def evidence(  # noqa: PLR0913
     )
 
 
+# @codescene(disable:"Excess Number of Function Arguments")
+# 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @export_app.command
 def reports(  # noqa: PLR0913
     *,
@@ -141,6 +145,8 @@ def reports(  # noqa: PLR0913
     )
 
 
+# @codescene(disable:"Excess Number of Function Arguments")
+# 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @export_app.command
 def bundle(  # noqa: PLR0913
     *,

--- a/ghillie/cli/commands/export.py
+++ b/ghillie/cli/commands/export.py
@@ -6,12 +6,16 @@ import typing as typ
 
 from cyclopts import App, Parameter
 
+from ghillie.cli.commands.params import (
+    ExportFormat,
+    ExportSinkOptions,
+    ResourceScope,
+    ResourceTarget,
+    WindowOptions,
+)
 from ghillie.cli.context import get_current_context
 from ghillie.cli.control_plane import ControlPlaneClient
 from ghillie.cli.output import render_output
-
-ExportScope = typ.Literal["repository", "estate"]
-ExportFormat = typ.Literal["json", "jsonl", "csv"]
 
 export_app = App(name="export", help="Export structured MVP data artefacts.")
 
@@ -31,37 +35,31 @@ def _api_placeholder(verb: str, **fields: object) -> str:
         )
 
 
-def _export_command(  # noqa: PLR0913
+def _export_command(
     kind: str,
     *,
-    scope: ExportScope,
-    estate_key: str | None = None,
-    owner: str | None = None,
-    name: str | None = None,
-    window_days: int | None = 14,
-    window_start: str | None = None,
-    window_end: str | None = None,
-    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = "json",
-    output_path: str,
+    target: ResourceTarget,
+    window: WindowOptions,
+    sink: ExportSinkOptions,
 ) -> str:
     return _api_placeholder(
         kind,
-        scope=scope,
-        estate_key=estate_key or "",
-        owner=owner or "",
-        name=name or "",
-        window_days=window_days if window_days is not None else "",
-        window_start=window_start or "",
-        window_end=window_end or "",
-        format=export_format,
-        output_path=output_path,
+        scope=target.scope,
+        estate_key=target.estate_key or "",
+        owner=target.owner or "",
+        name=target.name or "",
+        window_days=window.window_days if window.window_days is not None else "",
+        window_start=window.window_start or "",
+        window_end=window.window_end or "",
+        format=sink.export_format,
+        output_path=sink.output_path,
     )
 
 
 @export_app.command
 def events(  # noqa: PLR0913
     *,
-    scope: ExportScope,
+    scope: ResourceScope,
     estate_key: str | None = None,
     owner: str | None = None,
     name: str | None = None,
@@ -72,24 +70,18 @@ def events(  # noqa: PLR0913
     output_path: str,
 ) -> str:
     """Export Bronze and Silver event data."""
-    return _export_command(
-        "events",
-        scope=scope,
-        estate_key=estate_key,
-        owner=owner,
-        name=name,
-        window_days=window_days,
-        window_start=window_start,
-        window_end=window_end,
-        export_format=export_format,
-        output_path=output_path,
+    target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
+    window = WindowOptions(
+        window_days=window_days, window_start=window_start, window_end=window_end
     )
+    sink = ExportSinkOptions(export_format=export_format, output_path=output_path)
+    return _export_command("events", target=target, window=window, sink=sink)
 
 
 @export_app.command
 def evidence(  # noqa: PLR0913
     *,
-    scope: ExportScope,
+    scope: ResourceScope,
     estate_key: str | None = None,
     owner: str | None = None,
     name: str | None = None,
@@ -101,17 +93,22 @@ def evidence(  # noqa: PLR0913
     include_previous_reports: bool = False,
 ) -> str:
     """Export derived evidence bundles."""
+    target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
+    window = WindowOptions(
+        window_days=window_days, window_start=window_start, window_end=window_end
+    )
+    sink = ExportSinkOptions(export_format=export_format, output_path=output_path)
     return _api_placeholder(
         "evidence",
-        scope=scope,
-        estate_key=estate_key or "",
-        owner=owner or "",
-        name=name or "",
-        window_days=window_days if window_days is not None else "",
-        window_start=window_start or "",
-        window_end=window_end or "",
-        format=export_format,
-        output_path=output_path,
+        scope=target.scope,
+        estate_key=target.estate_key or "",
+        owner=target.owner or "",
+        name=target.name or "",
+        window_days=window.window_days if window.window_days is not None else "",
+        window_start=window.window_start or "",
+        window_end=window.window_end or "",
+        format=sink.export_format,
+        output_path=sink.output_path,
         include_previous_reports=include_previous_reports,
     )
 
@@ -119,7 +116,7 @@ def evidence(  # noqa: PLR0913
 @export_app.command
 def reports(  # noqa: PLR0913
     *,
-    scope: ExportScope,
+    scope: ResourceScope,
     estate_key: str | None = None,
     owner: str | None = None,
     name: str | None = None,
@@ -131,17 +128,22 @@ def reports(  # noqa: PLR0913
     include_coverage: bool = False,
 ) -> str:
     """Export report metadata and lineage."""
+    target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
+    window = WindowOptions(
+        window_days=window_days, window_start=window_start, window_end=window_end
+    )
+    sink = ExportSinkOptions(export_format=export_format, output_path=output_path)
     return _api_placeholder(
         "reports",
-        scope=scope,
-        estate_key=estate_key or "",
-        owner=owner or "",
-        name=name or "",
-        window_days=window_days if window_days is not None else "",
-        window_start=window_start or "",
-        window_end=window_end or "",
-        format=export_format,
-        output_path=output_path,
+        scope=target.scope,
+        estate_key=target.estate_key or "",
+        owner=target.owner or "",
+        name=target.name or "",
+        window_days=window.window_days if window.window_days is not None else "",
+        window_start=window.window_start or "",
+        window_end=window.window_end or "",
+        format=sink.export_format,
+        output_path=sink.output_path,
         include_coverage=include_coverage,
     )
 
@@ -149,7 +151,7 @@ def reports(  # noqa: PLR0913
 @export_app.command
 def bundle(  # noqa: PLR0913
     *,
-    scope: ExportScope,
+    scope: ResourceScope,
     estate_key: str | None = None,
     owner: str | None = None,
     name: str | None = None,
@@ -160,13 +162,15 @@ def bundle(  # noqa: PLR0913
     output_path: str,
 ) -> str:
     """Export a combined bundle artefact."""
+    target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
+    sink = ExportSinkOptions(export_format=export_format, output_path=output_path)
     return _api_placeholder(
         "bundle",
-        scope=scope,
-        estate_key=estate_key or "",
-        owner=owner or "",
-        name=name or "",
+        scope=target.scope,
+        estate_key=target.estate_key or "",
+        owner=target.owner or "",
+        name=target.name or "",
         window_days=window_days,
-        format=export_format,
-        output_path=output_path,
+        format=sink.export_format,
+        output_path=sink.output_path,
     )

--- a/ghillie/cli/commands/export.py
+++ b/ghillie/cli/commands/export.py
@@ -80,7 +80,25 @@ def events(
     window: WindowOptions | None = None,
     sink: ExportSinkOptions | None = None,
 ) -> str:
-    """Export Bronze and Silver event data."""
+    """Export Bronze and Silver event data.
+
+    Parameters
+    ----------
+    target : ResourceTarget
+        Target resource specification (scope, estate_key, owner, name).
+    window : WindowOptions | None, optional
+        Time window for event selection (window_days, window_start, window_end).
+        Defaults to WindowOptions() if None.
+    sink : ExportSinkOptions | None, optional
+        Export output configuration (export_format, output_path).
+        Defaults to ExportSinkOptions() if None.
+
+    Returns
+    -------
+    str
+        JSON-serialized export status response from the control plane.
+
+    """
     if window is None:
         window = WindowOptions()
     if sink is None:
@@ -106,7 +124,37 @@ def evidence(  # noqa: PLR0913
     output_path: str,
     include_previous_reports: bool = False,
 ) -> str:
-    """Export derived evidence bundles."""
+    """Export derived evidence bundles.
+
+    Parameters
+    ----------
+    scope : ResourceScope
+        Target scope (estate, organization, or repository).
+    estate_key : str | None, optional
+        Estate identifier. Default is None.
+    owner : str | None, optional
+        Owner (organization or user) identifier. Default is None.
+    name : str | None, optional
+        Repository name. Default is None.
+    window_days : int | None, optional
+        Number of days to include in the export window. Default is 14.
+    window_start : str | None, optional
+        ISO 8601 start timestamp for the export window. Default is None.
+    window_end : str | None, optional
+        ISO 8601 end timestamp for the export window. Default is None.
+    export_format : ExportFormat, optional
+        Output format (JSON, CSV, etc.). Default is ExportFormat.JSON.
+    output_path : str
+        File path for the exported data.
+    include_previous_reports : bool, optional
+        Whether to include previous report metadata. Default is False.
+
+    Returns
+    -------
+    str
+        JSON-serialized export status response from the control plane.
+
+    """
     target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
     window = WindowOptions(
         window_days=window_days, window_start=window_start, window_end=window_end
@@ -139,7 +187,37 @@ def reports(  # noqa: PLR0913
     output_path: str,
     include_coverage: bool = False,
 ) -> str:
-    """Export report metadata and lineage."""
+    """Export report metadata and lineage.
+
+    Parameters
+    ----------
+    scope : ResourceScope
+        Target scope (estate, organization, or repository).
+    estate_key : str | None, optional
+        Estate identifier. Default is None.
+    owner : str | None, optional
+        Owner (organization or user) identifier. Default is None.
+    name : str | None, optional
+        Repository name. Default is None.
+    window_days : int | None, optional
+        Number of days to include in the export window. Default is 14.
+    window_start : str | None, optional
+        ISO 8601 start timestamp for the export window. Default is None.
+    window_end : str | None, optional
+        ISO 8601 end timestamp for the export window. Default is None.
+    export_format : ExportFormat, optional
+        Output format (JSON, CSV, etc.). Default is ExportFormat.JSON.
+    output_path : str
+        File path for the exported data.
+    include_coverage : bool, optional
+        Whether to include coverage metrics in the export. Default is False.
+
+    Returns
+    -------
+    str
+        JSON-serialized export status response from the control plane.
+
+    """
     target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
     window = WindowOptions(
         window_days=window_days, window_start=window_start, window_end=window_end
@@ -169,7 +247,31 @@ def bundle(  # noqa: PLR0913
     ),
     output_path: str,
 ) -> str:
-    """Export a combined bundle artefact."""
+    """Export a combined bundle artefact.
+
+    Parameters
+    ----------
+    scope : ResourceScope
+        Target scope (estate, organization, or repository).
+    estate_key : str | None, optional
+        Estate identifier. Default is None.
+    owner : str | None, optional
+        Owner (organization or user) identifier. Default is None.
+    name : str | None, optional
+        Repository name. Default is None.
+    window_days : int, optional
+        Number of days to include in the export window. Default is 14.
+    export_format : ExportFormat, optional
+        Output format (JSON, CSV, etc.). Default is ExportFormat.JSON.
+    output_path : str
+        File path for the exported bundle.
+
+    Returns
+    -------
+    str
+        JSON-serialized export status response from the control plane.
+
+    """
     target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
     sink = ExportSinkOptions(export_format=export_format, output_path=Path(output_path))
     return _api_placeholder(

--- a/ghillie/cli/commands/export.py
+++ b/ghillie/cli/commands/export.py
@@ -54,13 +54,13 @@ def _flatten_sink(sink: ExportSinkOptions) -> dict[str, str]:
     }
 
 
-def _export_command(  # noqa: PLR0913
+def _export_command(
     kind: str,
     *,
     target: ResourceTarget,
     window: WindowOptions,
     sink: ExportSinkOptions,
-    extra_fields: typ.Mapping[str, object] | None = None,
+    **extra_fields: object,
 ) -> str:
     return _api_placeholder(
         kind,
@@ -69,7 +69,7 @@ def _export_command(  # noqa: PLR0913
         window_start=window.window_start or "",
         window_end=window.window_end or "",
         **_flatten_sink(sink),
-        **(extra_fields or {}),
+        **extra_fields,
     )
 
 
@@ -91,7 +91,7 @@ def events(
 # @codescene(disable:"Excess Number of Function Arguments")
 # 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @export_app.command
-def evidence(  # noqa: PLR0913  # FIXME: CLI entry point must expose all options explicitly for operator UX
+def evidence(  # noqa: PLR0913
     *,
     scope: ResourceScope,
     estate_key: str | None = None,
@@ -117,14 +117,14 @@ def evidence(  # noqa: PLR0913  # FIXME: CLI entry point must expose all options
         target=target,
         window=window,
         sink=sink,
-        extra_fields={"include_previous_reports": include_previous_reports},
+        include_previous_reports=include_previous_reports,
     )
 
 
 # @codescene(disable:"Excess Number of Function Arguments")
 # 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @export_app.command
-def reports(  # noqa: PLR0913  # FIXME: CLI entry point must expose all options explicitly for operator UX
+def reports(  # noqa: PLR0913
     *,
     scope: ResourceScope,
     estate_key: str | None = None,
@@ -150,23 +150,23 @@ def reports(  # noqa: PLR0913  # FIXME: CLI entry point must expose all options 
         target=target,
         window=window,
         sink=sink,
-        extra_fields={"include_coverage": include_coverage},
+        include_coverage=include_coverage,
     )
 
 
 # @codescene(disable:"Excess Number of Function Arguments")
 # 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @export_app.command
-def bundle(  # noqa: PLR0913  # FIXME: CLI entry point must expose all options explicitly for operator UX
+def bundle(  # noqa: PLR0913
     *,
     scope: ResourceScope,
     estate_key: str | None = None,
     owner: str | None = None,
     name: str | None = None,
     window_days: int = 14,
-    export_format: typ.Annotated[
-        typ.Literal[ExportFormat.JSON], Parameter(name="--format")
-    ] = ExportFormat.JSON,
+    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = (
+        ExportFormat.JSON
+    ),
     output_path: str,
 ) -> str:
     """Export a combined bundle artefact."""

--- a/ghillie/cli/commands/export.py
+++ b/ghillie/cli/commands/export.py
@@ -1,0 +1,172 @@
+"""Export noun commands for the packaged operator CLI."""
+
+from __future__ import annotations
+
+import typing as typ
+
+from cyclopts import App, Parameter
+
+from ghillie.cli.context import get_current_context
+from ghillie.cli.control_plane import ControlPlaneClient
+from ghillie.cli.output import render_output
+
+ExportScope = typ.Literal["repository", "estate"]
+ExportFormat = typ.Literal["json", "jsonl", "csv"]
+
+export_app = App(name="export", help="Export structured MVP data artefacts.")
+
+
+def _api_placeholder(verb: str, **fields: object) -> str:
+    context = get_current_context()
+    with ControlPlaneClient(context.config):
+        return render_output(
+            {
+                "noun": "export",
+                "verb": verb,
+                "status": "not_implemented",
+                "message": "not implemented in Task 2.5.a",
+                **fields,
+            },
+            output=context.config.output,
+        )
+
+
+def _export_command(  # noqa: PLR0913
+    kind: str,
+    *,
+    scope: ExportScope,
+    estate_key: str | None = None,
+    owner: str | None = None,
+    name: str | None = None,
+    window_days: int | None = 14,
+    window_start: str | None = None,
+    window_end: str | None = None,
+    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = "json",
+    output_path: str,
+) -> str:
+    return _api_placeholder(
+        kind,
+        scope=scope,
+        estate_key=estate_key or "",
+        owner=owner or "",
+        name=name or "",
+        window_days=window_days if window_days is not None else "",
+        window_start=window_start or "",
+        window_end=window_end or "",
+        format=export_format,
+        output_path=output_path,
+    )
+
+
+@export_app.command
+def events(  # noqa: PLR0913
+    *,
+    scope: ExportScope,
+    estate_key: str | None = None,
+    owner: str | None = None,
+    name: str | None = None,
+    window_days: int | None = 14,
+    window_start: str | None = None,
+    window_end: str | None = None,
+    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = "json",
+    output_path: str,
+) -> str:
+    """Export Bronze and Silver event data."""
+    return _export_command(
+        "events",
+        scope=scope,
+        estate_key=estate_key,
+        owner=owner,
+        name=name,
+        window_days=window_days,
+        window_start=window_start,
+        window_end=window_end,
+        export_format=export_format,
+        output_path=output_path,
+    )
+
+
+@export_app.command
+def evidence(  # noqa: PLR0913
+    *,
+    scope: ExportScope,
+    estate_key: str | None = None,
+    owner: str | None = None,
+    name: str | None = None,
+    window_days: int | None = 14,
+    window_start: str | None = None,
+    window_end: str | None = None,
+    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = "json",
+    output_path: str,
+    include_previous_reports: bool = False,
+) -> str:
+    """Export derived evidence bundles."""
+    return _api_placeholder(
+        "evidence",
+        scope=scope,
+        estate_key=estate_key or "",
+        owner=owner or "",
+        name=name or "",
+        window_days=window_days if window_days is not None else "",
+        window_start=window_start or "",
+        window_end=window_end or "",
+        format=export_format,
+        output_path=output_path,
+        include_previous_reports=include_previous_reports,
+    )
+
+
+@export_app.command
+def reports(  # noqa: PLR0913
+    *,
+    scope: ExportScope,
+    estate_key: str | None = None,
+    owner: str | None = None,
+    name: str | None = None,
+    window_days: int | None = 14,
+    window_start: str | None = None,
+    window_end: str | None = None,
+    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = "json",
+    output_path: str,
+    include_coverage: bool = False,
+) -> str:
+    """Export report metadata and lineage."""
+    return _api_placeholder(
+        "reports",
+        scope=scope,
+        estate_key=estate_key or "",
+        owner=owner or "",
+        name=name or "",
+        window_days=window_days if window_days is not None else "",
+        window_start=window_start or "",
+        window_end=window_end or "",
+        format=export_format,
+        output_path=output_path,
+        include_coverage=include_coverage,
+    )
+
+
+@export_app.command
+def bundle(  # noqa: PLR0913
+    *,
+    scope: ExportScope,
+    estate_key: str | None = None,
+    owner: str | None = None,
+    name: str | None = None,
+    window_days: int = 14,
+    export_format: typ.Annotated[
+        typ.Literal["json"], Parameter(name="--format")
+    ] = "json",
+    output_path: str,
+) -> str:
+    """Export a combined bundle artefact."""
+    return _api_placeholder(
+        "bundle",
+        scope=scope,
+        estate_key=estate_key or "",
+        owner=owner or "",
+        name=name or "",
+        window_days=window_days,
+        format=export_format,
+        output_path=output_path,
+    )

--- a/ghillie/cli/commands/export.py
+++ b/ghillie/cli/commands/export.py
@@ -36,6 +36,24 @@ def _api_placeholder(verb: str, **fields: object) -> str:
         )
 
 
+def _flatten_target(target: ResourceTarget) -> dict[str, str]:
+    """Flatten ResourceTarget fields for serialization."""
+    return {
+        "scope": target.scope,
+        "estate_key": target.estate_key or "",
+        "owner": target.owner or "",
+        "name": target.name or "",
+    }
+
+
+def _flatten_sink(sink: ExportSinkOptions) -> dict[str, str]:
+    """Flatten ExportSinkOptions fields for serialization."""
+    return {
+        "format": sink.export_format,
+        "output_path": str(sink.output_path),
+    }
+
+
 def _export_command(  # noqa: PLR0913
     kind: str,
     *,
@@ -46,15 +64,11 @@ def _export_command(  # noqa: PLR0913
 ) -> str:
     return _api_placeholder(
         kind,
-        scope=target.scope,
-        estate_key=target.estate_key or "",
-        owner=target.owner or "",
-        name=target.name or "",
+        **_flatten_target(target),
         window_days=window.window_days if window.window_days is not None else "",
         window_start=window.window_start or "",
         window_end=window.window_end or "",
-        format=sink.export_format,
-        output_path=str(sink.output_path),
+        **_flatten_sink(sink),
         **(extra_fields or {}),
     )
 
@@ -77,7 +91,7 @@ def events(
 # @codescene(disable:"Excess Number of Function Arguments")
 # 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @export_app.command
-def evidence(  # noqa: PLR0913
+def evidence(  # noqa: PLR0913  # FIXME: CLI entry point must expose all options explicitly for operator UX
     *,
     scope: ResourceScope,
     estate_key: str | None = None,
@@ -110,7 +124,7 @@ def evidence(  # noqa: PLR0913
 # @codescene(disable:"Excess Number of Function Arguments")
 # 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @export_app.command
-def reports(  # noqa: PLR0913
+def reports(  # noqa: PLR0913  # FIXME: CLI entry point must expose all options explicitly for operator UX
     *,
     scope: ResourceScope,
     estate_key: str | None = None,
@@ -143,7 +157,7 @@ def reports(  # noqa: PLR0913
 # @codescene(disable:"Excess Number of Function Arguments")
 # 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @export_app.command
-def bundle(  # noqa: PLR0913
+def bundle(  # noqa: PLR0913  # FIXME: CLI entry point must expose all options explicitly for operator UX
     *,
     scope: ResourceScope,
     estate_key: str | None = None,
@@ -160,11 +174,7 @@ def bundle(  # noqa: PLR0913
     sink = ExportSinkOptions(export_format=export_format, output_path=Path(output_path))
     return _api_placeholder(
         "bundle",
-        scope=target.scope,
-        estate_key=target.estate_key or "",
-        owner=target.owner or "",
-        name=target.name or "",
+        **_flatten_target(target),
         window_days=window_days,
-        format=sink.export_format,
-        output_path=str(sink.output_path),
+        **_flatten_sink(sink),
     )

--- a/ghillie/cli/commands/export.py
+++ b/ghillie/cli/commands/export.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import typing as typ
+from pathlib import Path
 
 from cyclopts import App, Parameter
 
@@ -35,12 +36,13 @@ def _api_placeholder(verb: str, **fields: object) -> str:
         )
 
 
-def _export_command(
+def _export_command(  # noqa: PLR0913
     kind: str,
     *,
     target: ResourceTarget,
     window: WindowOptions,
     sink: ExportSinkOptions,
+    extra_fields: typ.Mapping[str, object] | None = None,
 ) -> str:
     return _api_placeholder(
         kind,
@@ -52,7 +54,8 @@ def _export_command(
         window_start=window.window_start or "",
         window_end=window.window_end or "",
         format=sink.export_format,
-        output_path=sink.output_path,
+        output_path=str(sink.output_path),
+        **(extra_fields or {}),
     )
 
 
@@ -83,7 +86,9 @@ def evidence(  # noqa: PLR0913
     window_days: int | None = 14,
     window_start: str | None = None,
     window_end: str | None = None,
-    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = "json",
+    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = (
+        ExportFormat.JSON
+    ),
     output_path: str,
     include_previous_reports: bool = False,
 ) -> str:
@@ -92,19 +97,13 @@ def evidence(  # noqa: PLR0913
     window = WindowOptions(
         window_days=window_days, window_start=window_start, window_end=window_end
     )
-    sink = ExportSinkOptions(export_format=export_format, output_path=output_path)
-    return _api_placeholder(
+    sink = ExportSinkOptions(export_format=export_format, output_path=Path(output_path))
+    return _export_command(
         "evidence",
-        scope=target.scope,
-        estate_key=target.estate_key or "",
-        owner=target.owner or "",
-        name=target.name or "",
-        window_days=window.window_days if window.window_days is not None else "",
-        window_start=window.window_start or "",
-        window_end=window.window_end or "",
-        format=sink.export_format,
-        output_path=sink.output_path,
-        include_previous_reports=include_previous_reports,
+        target=target,
+        window=window,
+        sink=sink,
+        extra_fields={"include_previous_reports": include_previous_reports},
     )
 
 
@@ -120,7 +119,9 @@ def reports(  # noqa: PLR0913
     window_days: int | None = 14,
     window_start: str | None = None,
     window_end: str | None = None,
-    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = "json",
+    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = (
+        ExportFormat.JSON
+    ),
     output_path: str,
     include_coverage: bool = False,
 ) -> str:
@@ -129,19 +130,13 @@ def reports(  # noqa: PLR0913
     window = WindowOptions(
         window_days=window_days, window_start=window_start, window_end=window_end
     )
-    sink = ExportSinkOptions(export_format=export_format, output_path=output_path)
-    return _api_placeholder(
+    sink = ExportSinkOptions(export_format=export_format, output_path=Path(output_path))
+    return _export_command(
         "reports",
-        scope=target.scope,
-        estate_key=target.estate_key or "",
-        owner=target.owner or "",
-        name=target.name or "",
-        window_days=window.window_days if window.window_days is not None else "",
-        window_start=window.window_start or "",
-        window_end=window.window_end or "",
-        format=sink.export_format,
-        output_path=sink.output_path,
-        include_coverage=include_coverage,
+        target=target,
+        window=window,
+        sink=sink,
+        extra_fields={"include_coverage": include_coverage},
     )
 
 
@@ -156,13 +151,13 @@ def bundle(  # noqa: PLR0913
     name: str | None = None,
     window_days: int = 14,
     export_format: typ.Annotated[
-        typ.Literal["json"], Parameter(name="--format")
-    ] = "json",
+        typ.Literal[ExportFormat.JSON], Parameter(name="--format")
+    ] = ExportFormat.JSON,
     output_path: str,
 ) -> str:
     """Export a combined bundle artefact."""
     target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
-    sink = ExportSinkOptions(export_format=export_format, output_path=output_path)
+    sink = ExportSinkOptions(export_format=export_format, output_path=Path(output_path))
     return _api_placeholder(
         "bundle",
         scope=target.scope,
@@ -171,5 +166,5 @@ def bundle(  # noqa: PLR0913
         name=target.name or "",
         window_days=window_days,
         format=sink.export_format,
-        output_path=sink.output_path,
+        output_path=str(sink.output_path),
     )

--- a/ghillie/cli/commands/export.py
+++ b/ghillie/cli/commands/export.py
@@ -57,24 +57,17 @@ def _export_command(
 
 
 @export_app.command
-def events(  # noqa: PLR0913
+def events(
     *,
-    scope: ResourceScope,
-    estate_key: str | None = None,
-    owner: str | None = None,
-    name: str | None = None,
-    window_days: int | None = 14,
-    window_start: str | None = None,
-    window_end: str | None = None,
-    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = "json",
-    output_path: str,
+    target: ResourceTarget,
+    window: WindowOptions | None = None,
+    sink: ExportSinkOptions | None = None,
 ) -> str:
     """Export Bronze and Silver event data."""
-    target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
-    window = WindowOptions(
-        window_days=window_days, window_start=window_start, window_end=window_end
-    )
-    sink = ExportSinkOptions(export_format=export_format, output_path=output_path)
+    if window is None:
+        window = WindowOptions()
+    if sink is None:
+        sink = ExportSinkOptions()
     return _export_command("events", target=target, window=window, sink=sink)
 
 

--- a/ghillie/cli/commands/ingest.py
+++ b/ghillie/cli/commands/ingest.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import typing as typ
-
 from cyclopts import App
 
+from ghillie.cli.commands.params import ResourceScope, ResourceTarget
 from ghillie.cli.context import get_current_context
 from ghillie.cli.control_plane import ControlPlaneClient
 from ghillie.cli.output import render_output
-
-IngestScope = typ.Literal["repository", "estate"]
 
 ingest_app = App(name="ingest", help="Trigger and observe ingestion runs.")
 
@@ -33,7 +30,7 @@ def _api_placeholder(verb: str, **fields: object) -> str:
 @ingest_app.command
 def run(  # noqa: PLR0913
     *,
-    scope: IngestScope,
+    scope: ResourceScope,
     estate_key: str | None = None,
     owner: str | None = None,
     name: str | None = None,
@@ -42,12 +39,13 @@ def run(  # noqa: PLR0913
     wait: bool = True,
 ) -> str:
     """Start a scaffolded ingestion run."""
+    target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
     return _api_placeholder(
         "run",
-        scope=scope,
-        estate_key=estate_key or "",
-        owner=owner or "",
-        name=name or "",
+        scope=target.scope,
+        estate_key=target.estate_key or "",
+        owner=target.owner or "",
+        name=target.name or "",
         lookback_days=lookback_days,
         max_events_per_kind=max_events_per_kind or "service-default",
         wait=wait,

--- a/ghillie/cli/commands/ingest.py
+++ b/ghillie/cli/commands/ingest.py
@@ -1,0 +1,70 @@
+"""Ingest noun commands for the packaged operator CLI."""
+
+from __future__ import annotations
+
+import typing as typ
+
+from cyclopts import App
+
+from ghillie.cli.context import get_current_context
+from ghillie.cli.control_plane import ControlPlaneClient
+from ghillie.cli.output import render_output
+
+IngestScope = typ.Literal["repository", "estate"]
+
+ingest_app = App(name="ingest", help="Trigger and observe ingestion runs.")
+
+
+def _api_placeholder(verb: str, **fields: object) -> str:
+    context = get_current_context()
+    with ControlPlaneClient(context.config):
+        return render_output(
+            {
+                "noun": "ingest",
+                "verb": verb,
+                "status": "not_implemented",
+                "message": "not implemented in Task 2.5.a",
+                **fields,
+            },
+            output=context.config.output,
+        )
+
+
+@ingest_app.command
+def run(  # noqa: PLR0913
+    *,
+    scope: IngestScope,
+    estate_key: str | None = None,
+    owner: str | None = None,
+    name: str | None = None,
+    lookback_days: int = 14,
+    max_events_per_kind: int | None = None,
+    wait: bool = True,
+) -> str:
+    """Start a scaffolded ingestion run."""
+    return _api_placeholder(
+        "run",
+        scope=scope,
+        estate_key=estate_key or "",
+        owner=owner or "",
+        name=name or "",
+        lookback_days=lookback_days,
+        max_events_per_kind=max_events_per_kind or "service-default",
+        wait=wait,
+    )
+
+
+@ingest_app.command
+def status(*, run_id: str) -> str:
+    """Fetch status for one ingestion run."""
+    return _api_placeholder("status", run_id=run_id)
+
+
+@ingest_app.command
+def watch(*, run_id: str, poll_interval_s: float = 2.0) -> str:
+    """Poll a scaffolded ingestion run."""
+    return _api_placeholder(
+        "watch",
+        run_id=run_id,
+        poll_interval_s=poll_interval_s,
+    )

--- a/ghillie/cli/commands/ingest.py
+++ b/ghillie/cli/commands/ingest.py
@@ -27,6 +27,8 @@ def _api_placeholder(verb: str, **fields: object) -> str:
         )
 
 
+# @codescene(disable:"Excess Number of Function Arguments")
+# 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @ingest_app.command
 def run(  # noqa: PLR0913
     *,

--- a/ghillie/cli/commands/metrics.py
+++ b/ghillie/cli/commands/metrics.py
@@ -1,0 +1,78 @@
+"""Metrics noun commands for the packaged operator CLI."""
+
+from __future__ import annotations
+
+import typing as typ
+
+from cyclopts import App
+
+from ghillie.cli.context import get_current_context
+from ghillie.cli.control_plane import ControlPlaneClient
+from ghillie.cli.output import render_output
+
+MetricsScope = typ.Literal["repository", "estate"]
+
+metrics_app = App(name="metrics", help="Query MVP metrics views.")
+
+
+def _api_placeholder(verb: str, **fields: object) -> str:
+    context = get_current_context()
+    with ControlPlaneClient(context.config):
+        return render_output(
+            {
+                "noun": "metrics",
+                "verb": verb,
+                "status": "not_implemented",
+                "message": "not implemented in Task 2.5.a",
+                **fields,
+            },
+            output=context.config.output,
+        )
+
+
+@metrics_app.command(name="required")
+def required_metrics(  # noqa: PLR0913
+    *,
+    scope: MetricsScope,
+    estate_key: str | None = None,
+    owner: str | None = None,
+    name: str | None = None,
+    window_days: int = 14,
+    group_by: str = "repo",
+) -> str:
+    """Return required MVP metrics for a selected window."""
+    return _api_placeholder(
+        "required",
+        scope=scope,
+        estate_key=estate_key or "",
+        owner=owner or "",
+        name=name or "",
+        window_days=window_days,
+        group_by=group_by,
+    )
+
+
+@metrics_app.command(name="nice")
+def nice_metrics(  # noqa: PLR0913
+    *,
+    scope: MetricsScope,
+    estate_key: str | None = None,
+    owner: str | None = None,
+    name: str | None = None,
+    window_days: int = 14,
+    include_comments: bool = False,
+    include_commit_counts: bool = False,
+    include_sloc_breakdown: bool = False,
+) -> str:
+    """Return optional MVP metrics when data is available."""
+    return _api_placeholder(
+        "nice",
+        scope=scope,
+        estate_key=estate_key or "",
+        owner=owner or "",
+        name=name or "",
+        window_days=window_days,
+        include_comments=include_comments,
+        include_commit_counts=include_commit_counts,
+        include_sloc_breakdown=include_sloc_breakdown,
+    )

--- a/ghillie/cli/commands/metrics.py
+++ b/ghillie/cli/commands/metrics.py
@@ -31,6 +31,8 @@ def _api_placeholder(verb: str, **fields: object) -> str:
         )
 
 
+# @codescene(disable:"Excess Number of Function Arguments")
+# 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @metrics_app.command(name="required")
 def required_metrics(  # noqa: PLR0913
     *,

--- a/ghillie/cli/commands/metrics.py
+++ b/ghillie/cli/commands/metrics.py
@@ -55,24 +55,15 @@ def required_metrics(  # noqa: PLR0913
 
 
 @metrics_app.command(name="nice")
-def nice_metrics(  # noqa: PLR0913
+def nice_metrics(
     *,
-    scope: ResourceScope,
-    estate_key: str | None = None,
-    owner: str | None = None,
-    name: str | None = None,
+    target: ResourceTarget,
     window_days: int = 14,
-    include_comments: bool = False,
-    include_commit_counts: bool = False,
-    include_sloc_breakdown: bool = False,
+    opts: NiceMetricsOptions | None = None,
 ) -> str:
     """Return optional MVP metrics when data is available."""
-    target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
-    opts = NiceMetricsOptions(
-        include_comments=include_comments,
-        include_commit_counts=include_commit_counts,
-        include_sloc_breakdown=include_sloc_breakdown,
-    )
+    if opts is None:
+        opts = NiceMetricsOptions()
     return _api_placeholder(
         "nice",
         scope=target.scope,

--- a/ghillie/cli/commands/metrics.py
+++ b/ghillie/cli/commands/metrics.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-import typing as typ
-
 from cyclopts import App
 
+from ghillie.cli.commands.params import (
+    NiceMetricsOptions,
+    ResourceScope,
+    ResourceTarget,
+)
 from ghillie.cli.context import get_current_context
 from ghillie.cli.control_plane import ControlPlaneClient
 from ghillie.cli.output import render_output
-
-MetricsScope = typ.Literal["repository", "estate"]
 
 metrics_app = App(name="metrics", help="Query MVP metrics views.")
 
@@ -33,7 +34,7 @@ def _api_placeholder(verb: str, **fields: object) -> str:
 @metrics_app.command(name="required")
 def required_metrics(  # noqa: PLR0913
     *,
-    scope: MetricsScope,
+    scope: ResourceScope,
     estate_key: str | None = None,
     owner: str | None = None,
     name: str | None = None,
@@ -41,12 +42,13 @@ def required_metrics(  # noqa: PLR0913
     group_by: str = "repo",
 ) -> str:
     """Return required MVP metrics for a selected window."""
+    target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
     return _api_placeholder(
         "required",
-        scope=scope,
-        estate_key=estate_key or "",
-        owner=owner or "",
-        name=name or "",
+        scope=target.scope,
+        estate_key=target.estate_key or "",
+        owner=target.owner or "",
+        name=target.name or "",
         window_days=window_days,
         group_by=group_by,
     )
@@ -55,7 +57,7 @@ def required_metrics(  # noqa: PLR0913
 @metrics_app.command(name="nice")
 def nice_metrics(  # noqa: PLR0913
     *,
-    scope: MetricsScope,
+    scope: ResourceScope,
     estate_key: str | None = None,
     owner: str | None = None,
     name: str | None = None,
@@ -65,14 +67,20 @@ def nice_metrics(  # noqa: PLR0913
     include_sloc_breakdown: bool = False,
 ) -> str:
     """Return optional MVP metrics when data is available."""
-    return _api_placeholder(
-        "nice",
-        scope=scope,
-        estate_key=estate_key or "",
-        owner=owner or "",
-        name=name or "",
-        window_days=window_days,
+    target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
+    opts = NiceMetricsOptions(
         include_comments=include_comments,
         include_commit_counts=include_commit_counts,
         include_sloc_breakdown=include_sloc_breakdown,
+    )
+    return _api_placeholder(
+        "nice",
+        scope=target.scope,
+        estate_key=target.estate_key or "",
+        owner=target.owner or "",
+        name=target.name or "",
+        window_days=window_days,
+        include_comments=opts.include_comments,
+        include_commit_counts=opts.include_commit_counts,
+        include_sloc_breakdown=opts.include_sloc_breakdown,
     )

--- a/ghillie/cli/commands/params.py
+++ b/ghillie/cli/commands/params.py
@@ -1,0 +1,102 @@
+"""Parameter objects for CLI command functions."""
+
+from __future__ import annotations
+
+import dataclasses
+import typing as typ
+
+from cyclopts import Parameter
+
+ResourceScope = typ.Literal["repository", "estate"]
+ExportFormat = typ.Literal["json", "jsonl", "csv"]
+ModelBackend = typ.Literal["mock", "openai"]
+StackProfile = typ.Literal["api-only", "ingestion-worker", "reporting-worker"]
+RuntimeBackend = typ.Literal["cuprum", "python-api"]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ResourceTarget:
+    """Scope and identity for resource-targeted commands."""
+
+    scope: ResourceScope
+    estate_key: str | None = None
+    owner: str | None = None
+    name: str | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class WindowOptions:
+    """Time window configuration for data export and reporting."""
+
+    window_days: int | None = 14
+    window_start: str | None = None
+    window_end: str | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ExportSinkOptions:
+    """Export output format and destination configuration."""
+
+    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = "json"
+    output_path: str = ""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PaginationFilter:
+    """Pagination and active/inactive filter configuration."""
+
+    active: bool = True
+    inactive: bool = False
+    limit: int = 50
+    offset: int = 0
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class NiceMetricsOptions:
+    """Optional metrics inclusion flags."""
+
+    include_comments: bool = False
+    include_commit_counts: bool = False
+    include_sloc_breakdown: bool = False
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReportRunOptions:
+    """Report execution configuration."""
+
+    as_of: str | None = None
+    model_backend: ModelBackend = "mock"
+    wait: bool = True
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class StackRunOptions:
+    """Stack lifecycle profile and execution configuration."""
+
+    profile: StackProfile = "api-only"
+    backend: RuntimeBackend = "cuprum"
+    background_workers: bool = False
+    wait: bool = True
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ClusterOptions:
+    """Cluster identity and image configuration."""
+
+    cluster_name: typ.Annotated[str, Parameter(env_var="GHILLIE_CLUSTER_NAME")] = (
+        "ghillie-local"
+    )
+    namespace: typ.Annotated[str, Parameter(env_var="GHILLIE_NAMESPACE")] = "ghillie"
+    ingress_port: typ.Annotated[
+        int | None, Parameter(env_var="GHILLIE_INGRESS_PORT")
+    ] = None
+    image: typ.Annotated[str, Parameter(env_var="GHILLIE_IMAGE")] = "ghillie:local"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ProviderOptions:
+    """External provider credential and backend configuration."""
+
+    provider_github_token_env: str = "GHILLIE_GITHUB_TOKEN"  # noqa: S105
+    provider_model_backend: ModelBackend = "mock"
+    provider_openai_key_env: str = "GHILLIE_OPENAI_API_KEY"

--- a/ghillie/cli/commands/params.py
+++ b/ghillie/cli/commands/params.py
@@ -3,15 +3,48 @@
 from __future__ import annotations
 
 import dataclasses
+import enum
 import typing as typ
+from pathlib import Path
 
 from cyclopts import Parameter
 
-ResourceScope = typ.Literal["repository", "estate"]
-ExportFormat = typ.Literal["json", "jsonl", "csv"]
-ModelBackend = typ.Literal["mock", "openai"]
-StackProfile = typ.Literal["api-only", "ingestion-worker", "reporting-worker"]
-RuntimeBackend = typ.Literal["cuprum", "python-api"]
+
+class ResourceScope(enum.StrEnum):
+    """Scope for resource-targeted commands."""
+
+    REPOSITORY = "repository"
+    ESTATE = "estate"
+
+
+class ExportFormat(enum.StrEnum):
+    """Export output format."""
+
+    JSON = "json"
+    JSONL = "jsonl"
+    CSV = "csv"
+
+
+class ModelBackend(enum.StrEnum):
+    """LLM backend provider."""
+
+    MOCK = "mock"
+    OPENAI = "openai"
+
+
+class StackProfile(enum.StrEnum):
+    """Stack component profile."""
+
+    API_ONLY = "api-only"
+    INGESTION_WORKER = "ingestion-worker"
+    REPORTING_WORKER = "reporting-worker"
+
+
+class RuntimeBackend(enum.StrEnum):
+    """Local runtime orchestration backend."""
+
+    CUPRUM = "cuprum"
+    PYTHON_API = "python-api"
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -37,8 +70,10 @@ class WindowOptions:
 class ExportSinkOptions:
     """Export output format and destination configuration."""
 
-    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = "json"
-    output_path: str = ""
+    export_format: typ.Annotated[ExportFormat, Parameter(name="--format")] = (
+        ExportFormat.JSON
+    )
+    output_path: Path = dataclasses.field(default_factory=Path)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -65,7 +100,7 @@ class ReportRunOptions:
     """Report execution configuration."""
 
     as_of: str | None = None
-    model_backend: ModelBackend = "mock"
+    model_backend: ModelBackend = ModelBackend.MOCK
     wait: bool = True
 
 
@@ -73,8 +108,8 @@ class ReportRunOptions:
 class StackRunOptions:
     """Stack lifecycle profile and execution configuration."""
 
-    profile: StackProfile = "api-only"
-    backend: RuntimeBackend = "cuprum"
+    profile: StackProfile = StackProfile.API_ONLY
+    backend: RuntimeBackend = RuntimeBackend.CUPRUM
     background_workers: bool = False
     wait: bool = True
 
@@ -98,5 +133,5 @@ class ProviderOptions:
     """External provider credential and backend configuration."""
 
     provider_github_token_env: str = "GHILLIE_GITHUB_TOKEN"  # noqa: S105
-    provider_model_backend: ModelBackend = "mock"
+    provider_model_backend: ModelBackend = ModelBackend.MOCK
     provider_openai_key_env: str = "GHILLIE_OPENAI_API_KEY"

--- a/ghillie/cli/commands/report.py
+++ b/ghillie/cli/commands/report.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-import typing as typ
-
 from cyclopts import App
 
+from ghillie.cli.commands.params import (
+    ModelBackend,
+    ReportRunOptions,
+    ResourceScope,
+    ResourceTarget,
+)
 from ghillie.cli.context import get_current_context
 from ghillie.cli.control_plane import ControlPlaneClient
 from ghillie.cli.output import render_output
-
-ReportScope = typ.Literal["repository", "estate"]
-ModelBackend = typ.Literal["mock", "openai"]
 
 report_app = App(name="report", help="Trigger and observe reporting runs.")
 
@@ -34,7 +35,7 @@ def _api_placeholder(verb: str, **fields: object) -> str:
 @report_app.command
 def run(  # noqa: PLR0913
     *,
-    scope: ReportScope,
+    scope: ResourceScope,
     estate_key: str | None = None,
     owner: str | None = None,
     name: str | None = None,
@@ -44,16 +45,18 @@ def run(  # noqa: PLR0913
     wait: bool = True,
 ) -> str:
     """Start a scaffolded reporting run."""
+    target = ResourceTarget(scope=scope, estate_key=estate_key, owner=owner, name=name)
+    opts = ReportRunOptions(as_of=as_of, model_backend=model_backend, wait=wait)
     return _api_placeholder(
         "run",
-        scope=scope,
-        estate_key=estate_key or "",
-        owner=owner or "",
-        name=name or "",
+        scope=target.scope,
+        estate_key=target.estate_key or "",
+        owner=target.owner or "",
+        name=target.name or "",
         window_days=window_days,
-        as_of=as_of or "",
-        model_backend=model_backend,
-        wait=wait,
+        as_of=opts.as_of or "",
+        model_backend=opts.model_backend,
+        wait=opts.wait,
     )
 
 

--- a/ghillie/cli/commands/report.py
+++ b/ghillie/cli/commands/report.py
@@ -43,7 +43,7 @@ def run(  # noqa: PLR0913
     name: str | None = None,
     window_days: int = 14,
     as_of: str | None = None,
-    model_backend: ModelBackend = "mock",
+    model_backend: ModelBackend = ModelBackend.MOCK,
     wait: bool = True,
 ) -> str:
     """Start a scaffolded reporting run."""

--- a/ghillie/cli/commands/report.py
+++ b/ghillie/cli/commands/report.py
@@ -1,0 +1,73 @@
+"""Report noun commands for the packaged operator CLI."""
+
+from __future__ import annotations
+
+import typing as typ
+
+from cyclopts import App
+
+from ghillie.cli.context import get_current_context
+from ghillie.cli.control_plane import ControlPlaneClient
+from ghillie.cli.output import render_output
+
+ReportScope = typ.Literal["repository", "estate"]
+ModelBackend = typ.Literal["mock", "openai"]
+
+report_app = App(name="report", help="Trigger and observe reporting runs.")
+
+
+def _api_placeholder(verb: str, **fields: object) -> str:
+    context = get_current_context()
+    with ControlPlaneClient(context.config):
+        return render_output(
+            {
+                "noun": "report",
+                "verb": verb,
+                "status": "not_implemented",
+                "message": "not implemented in Task 2.5.a",
+                **fields,
+            },
+            output=context.config.output,
+        )
+
+
+@report_app.command
+def run(  # noqa: PLR0913
+    *,
+    scope: ReportScope,
+    estate_key: str | None = None,
+    owner: str | None = None,
+    name: str | None = None,
+    window_days: int = 14,
+    as_of: str | None = None,
+    model_backend: ModelBackend = "mock",
+    wait: bool = True,
+) -> str:
+    """Start a scaffolded reporting run."""
+    return _api_placeholder(
+        "run",
+        scope=scope,
+        estate_key=estate_key or "",
+        owner=owner or "",
+        name=name or "",
+        window_days=window_days,
+        as_of=as_of or "",
+        model_backend=model_backend,
+        wait=wait,
+    )
+
+
+@report_app.command
+def status(*, run_id: str) -> str:
+    """Query one report run."""
+    return _api_placeholder("status", run_id=run_id)
+
+
+@report_app.command
+def watch(*, run_id: str, poll_interval_s: float = 2.0) -> str:
+    """Watch one report run."""
+    return _api_placeholder(
+        "watch",
+        run_id=run_id,
+        poll_interval_s=poll_interval_s,
+    )

--- a/ghillie/cli/commands/report.py
+++ b/ghillie/cli/commands/report.py
@@ -32,6 +32,8 @@ def _api_placeholder(verb: str, **fields: object) -> str:
         )
 
 
+# @codescene(disable:"Excess Number of Function Arguments")
+# 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @report_app.command
 def run(  # noqa: PLR0913
     *,

--- a/ghillie/cli/commands/stack.py
+++ b/ghillie/cli/commands/stack.py
@@ -29,10 +29,10 @@ def up(  # noqa: PLR0913
     *,
     profile: typ.Annotated[
         StackProfile, Parameter(env_var="GHILLIE_PROFILE")
-    ] = "api-only",
+    ] = StackProfile.API_ONLY,
     backend: typ.Annotated[
         RuntimeBackend, Parameter(env_var="GHILLIE_BACKEND")
-    ] = "cuprum",
+    ] = RuntimeBackend.CUPRUM,
     cluster_name: typ.Annotated[
         str, Parameter(env_var="GHILLIE_CLUSTER_NAME")
     ] = "ghillie-local",
@@ -42,7 +42,7 @@ def up(  # noqa: PLR0913
     ] = None,
     image: typ.Annotated[str, Parameter(env_var="GHILLIE_IMAGE")] = "ghillie:local",
     provider_github_token_env: str = "GHILLIE_GITHUB_TOKEN",  # noqa: S107
-    provider_model_backend: ModelBackend = "mock",
+    provider_model_backend: ModelBackend = ModelBackend.MOCK,
     provider_openai_key_env: str = "GHILLIE_OPENAI_API_KEY",
     background_workers: bool = False,
     wait: bool = True,

--- a/ghillie/cli/commands/stack.py
+++ b/ghillie/cli/commands/stack.py
@@ -6,14 +6,18 @@ import typing as typ
 
 from cyclopts import App, Parameter
 
+from ghillie.cli.commands.params import (
+    ClusterOptions,
+    ModelBackend,
+    ProviderOptions,
+    RuntimeBackend,
+    StackProfile,
+    StackRunOptions,
+)
 from ghillie.cli.context import get_current_context
 from ghillie.cli.control_plane import ControlPlaneClient
 from ghillie.cli.output import render_output
 from ghillie.cli.runtime_adapters import select_runtime_adapter
-
-StackProfile = typ.Literal["api-only", "ingestion-worker", "reporting-worker"]
-ModelBackend = typ.Literal["mock", "openai"]
-RuntimeBackend = typ.Literal["cuprum", "python-api"]
 
 stack_app = App(name="stack", help="Manage the local MVP stack lifecycle.")
 
@@ -39,7 +43,24 @@ def up(  # noqa: PLR0913
 ) -> str:
     """Start the local stack scaffold without executing real integrations."""
     context = get_current_context()
-    adapter = select_runtime_adapter(backend)
+    run_opts = StackRunOptions(
+        profile=profile,
+        backend=backend,
+        background_workers=background_workers,
+        wait=wait,
+    )
+    cluster = ClusterOptions(
+        cluster_name=cluster_name,
+        namespace=namespace,
+        ingress_port=ingress_port,
+        image=image,
+    )
+    provider = ProviderOptions(
+        provider_github_token_env=provider_github_token_env,
+        provider_model_backend=provider_model_backend,
+        provider_openai_key_env=provider_openai_key_env,
+    )
+    adapter = select_runtime_adapter(run_opts.backend)
     return render_output(
         {
             "noun": "stack",
@@ -47,16 +68,16 @@ def up(  # noqa: PLR0913
             "status": "not_implemented",
             "message": "not implemented in Task 2.5.a",
             "backend": adapter.name,
-            "profile": profile,
-            "cluster_name": cluster_name,
-            "namespace": namespace,
-            "ingress_port": ingress_port or "auto",
-            "image": image,
-            "provider_github_token_env": provider_github_token_env,
-            "provider_model_backend": provider_model_backend,
-            "provider_openai_key_env": provider_openai_key_env,
-            "background_workers": background_workers,
-            "wait": wait,
+            "profile": run_opts.profile,
+            "cluster_name": cluster.cluster_name,
+            "namespace": cluster.namespace,
+            "ingress_port": cluster.ingress_port or "auto",
+            "image": cluster.image,
+            "provider_github_token_env": provider.provider_github_token_env,
+            "provider_model_backend": provider.provider_model_backend,
+            "provider_openai_key_env": provider.provider_openai_key_env,
+            "background_workers": run_opts.background_workers,
+            "wait": run_opts.wait,
             "dry_run": context.config.dry_run,
         },
         output=context.config.output,

--- a/ghillie/cli/commands/stack.py
+++ b/ghillie/cli/commands/stack.py
@@ -22,6 +22,8 @@ from ghillie.cli.runtime_adapters import select_runtime_adapter
 stack_app = App(name="stack", help="Manage the local MVP stack lifecycle.")
 
 
+# @codescene(disable:"Excess Number of Function Arguments")
+# 2026-03-22: CLI command entry point keeps explicit options for operator UX.
 @stack_app.command
 def up(  # noqa: PLR0913
     *,

--- a/ghillie/cli/commands/stack.py
+++ b/ghillie/cli/commands/stack.py
@@ -1,0 +1,141 @@
+"""Stack noun commands for the packaged operator CLI."""
+
+from __future__ import annotations
+
+import typing as typ
+
+from cyclopts import App, Parameter
+
+from ghillie.cli.context import get_current_context
+from ghillie.cli.control_plane import ControlPlaneClient
+from ghillie.cli.output import render_output
+from ghillie.cli.runtime_adapters import select_runtime_adapter
+
+StackProfile = typ.Literal["api-only", "ingestion-worker", "reporting-worker"]
+ModelBackend = typ.Literal["mock", "openai"]
+RuntimeBackend = typ.Literal["cuprum", "python-api"]
+
+stack_app = App(name="stack", help="Manage the local MVP stack lifecycle.")
+
+
+@stack_app.command
+def up(  # noqa: PLR0913
+    *,
+    profile: StackProfile = "api-only",
+    backend: RuntimeBackend = "cuprum",
+    cluster_name: typ.Annotated[
+        str, Parameter(env_var="GHILLIE_CLUSTER_NAME")
+    ] = "ghillie-local",
+    namespace: typ.Annotated[str, Parameter(env_var="GHILLIE_NAMESPACE")] = "ghillie",
+    ingress_port: typ.Annotated[
+        int | None, Parameter(env_var="GHILLIE_INGRESS_PORT")
+    ] = None,
+    image: typ.Annotated[str, Parameter(env_var="GHILLIE_IMAGE")] = "ghillie:local",
+    provider_github_token_env: str = "GHILLIE_GITHUB_TOKEN",  # noqa: S107
+    provider_model_backend: ModelBackend = "mock",
+    provider_openai_key_env: str = "GHILLIE_OPENAI_API_KEY",
+    background_workers: bool = False,
+    wait: bool = True,
+) -> str:
+    """Start the local stack scaffold without executing real integrations."""
+    context = get_current_context()
+    adapter = select_runtime_adapter(backend)
+    return render_output(
+        {
+            "noun": "stack",
+            "verb": "up",
+            "status": "not_implemented",
+            "message": "not implemented in Task 2.5.a",
+            "backend": adapter.name,
+            "profile": profile,
+            "cluster_name": cluster_name,
+            "namespace": namespace,
+            "ingress_port": ingress_port or "auto",
+            "image": image,
+            "provider_github_token_env": provider_github_token_env,
+            "provider_model_backend": provider_model_backend,
+            "provider_openai_key_env": provider_openai_key_env,
+            "background_workers": background_workers,
+            "wait": wait,
+            "dry_run": context.config.dry_run,
+        },
+        output=context.config.output,
+    )
+
+
+@stack_app.command
+def down(
+    *,
+    cluster_name: typ.Annotated[
+        str, Parameter(env_var="GHILLIE_CLUSTER_NAME")
+    ] = "ghillie-local",
+    purge_images: bool = False,
+    force: bool = False,
+) -> str:
+    """Tear down the local stack scaffold."""
+    context = get_current_context()
+    return render_output(
+        {
+            "noun": "stack",
+            "verb": "down",
+            "status": "not_implemented",
+            "message": "not implemented in Task 2.5.a",
+            "cluster_name": cluster_name,
+            "purge_images": purge_images,
+            "force": force,
+        },
+        output=context.config.output,
+    )
+
+
+@stack_app.command
+def status(
+    *,
+    cluster_name: typ.Annotated[
+        str, Parameter(env_var="GHILLIE_CLUSTER_NAME")
+    ] = "ghillie-local",
+    namespace: typ.Annotated[str, Parameter(env_var="GHILLIE_NAMESPACE")] = "ghillie",
+) -> str:
+    """Show the scaffolded stack status payload."""
+    context = get_current_context()
+    with ControlPlaneClient(context.config):
+        return render_output(
+            {
+                "noun": "stack",
+                "verb": "status",
+                "status": "not_implemented",
+                "message": "not implemented in Task 2.5.a",
+                "cluster_name": cluster_name,
+                "namespace": namespace,
+                "api_base_url": context.config.api_base_url,
+                "api_base_url_source": context.config.api_base_url_source,
+            },
+            output=context.config.output,
+        )
+
+
+@stack_app.command
+def logs(
+    *,
+    cluster_name: typ.Annotated[
+        str, Parameter(env_var="GHILLIE_CLUSTER_NAME")
+    ] = "ghillie-local",
+    namespace: typ.Annotated[str, Parameter(env_var="GHILLIE_NAMESPACE")] = "ghillie",
+    follow: bool = False,
+    since: str | None = None,
+) -> str:
+    """Show the scaffolded stack logs payload."""
+    context = get_current_context()
+    return render_output(
+        {
+            "noun": "stack",
+            "verb": "logs",
+            "status": "not_implemented",
+            "message": "not implemented in Task 2.5.a",
+            "cluster_name": cluster_name,
+            "namespace": namespace,
+            "follow": follow,
+            "since": since or "all",
+        },
+        output=context.config.output,
+    )

--- a/ghillie/cli/commands/stack.py
+++ b/ghillie/cli/commands/stack.py
@@ -27,8 +27,12 @@ stack_app = App(name="stack", help="Manage the local MVP stack lifecycle.")
 @stack_app.command
 def up(  # noqa: PLR0913
     *,
-    profile: StackProfile = "api-only",
-    backend: RuntimeBackend = "cuprum",
+    profile: typ.Annotated[
+        StackProfile, Parameter(env_var="GHILLIE_PROFILE")
+    ] = "api-only",
+    backend: typ.Annotated[
+        RuntimeBackend, Parameter(env_var="GHILLIE_BACKEND")
+    ] = "cuprum",
     cluster_name: typ.Annotated[
         str, Parameter(env_var="GHILLIE_CLUSTER_NAME")
     ] = "ghillie-local",

--- a/ghillie/cli/config.py
+++ b/ghillie/cli/config.py
@@ -137,7 +137,12 @@ def resolve_cli_config(
     environment = dict(env or {})
     profile = _load_profile(profile_path or default_profile_path())
     state = _load_state(state_path or default_state_path())
-    profile_global = typ.cast("typ.Mapping[str, object]", profile.get("global", {}))
+    global_section = profile.get("global", {})
+    if not isinstance(global_section, dict):
+        type_name = type(global_section).__name__
+        msg = f"[global] section in profile must be a table, found {type_name}"
+        raise TypeError(msg)
+    profile_global = typ.cast("typ.Mapping[str, object]", global_section)
 
     api_base_url, api_base_url_source = _resolve_api_base_url(
         options,
@@ -206,7 +211,12 @@ def _load_profile(path: Path) -> dict[str, object]:
 def _load_state(path: Path) -> dict[str, object]:
     if not path.exists():
         return {}
-    return json.loads(path.read_text(encoding="utf-8"))
+    content = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(content, dict):
+        type_name = type(content).__name__
+        msg = f"state.json must contain a JSON object, found {type_name}"
+        raise TypeError(msg)
+    return content
 
 
 def _validate_api_base_url(value: str) -> str:

--- a/ghillie/cli/config.py
+++ b/ghillie/cli/config.py
@@ -1,0 +1,234 @@
+"""Configuration resolution for the packaged operator CLI."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import tomllib
+import typing as typ
+from pathlib import Path
+from urllib.parse import urlparse
+
+OutputFormat = typ.Literal["table", "json", "yaml"]
+LogLevel = typ.Literal["debug", "info", "warn", "error"]
+ApiBaseUrlSource = typ.Literal["flag", "env", "profile", "state", "fallback"]
+
+_OUTPUT_VALUES = {"table", "json", "yaml"}
+_LOG_LEVEL_VALUES = {"debug", "info", "warn", "error"}
+_DEFAULT_API_BASE_URL = "http://127.0.0.1:8080"
+_DEFAULT_NON_INTERACTIVE = True
+_DEFAULT_DRY_RUN = False
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GlobalOptions:
+    """Raw root-global options captured before noun dispatch."""
+
+    api_base_url: str | None = None
+    auth_token: str | None = None
+    output: OutputFormat | None = None
+    log_level: LogLevel | None = None
+    request_timeout_s: float | None = None
+    non_interactive: bool | None = None
+    dry_run: bool | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ResolvedCliConfig:
+    """Effective CLI configuration after precedence resolution."""
+
+    api_base_url: str
+    api_base_url_source: ApiBaseUrlSource
+    auth_token: str | None
+    output: OutputFormat
+    log_level: LogLevel
+    request_timeout_s: float
+    non_interactive: bool
+    dry_run: bool
+
+
+def default_profile_path() -> Path:
+    """Return the default CLI profile path."""
+    return Path.home() / ".config" / "ghillie" / "cli.toml"
+
+
+def default_state_path() -> Path:
+    """Return the default persisted state path."""
+    return Path.home() / ".config" / "ghillie" / "state.json"
+
+
+def resolve_cli_config(
+    options: GlobalOptions,
+    *,
+    env: typ.Mapping[str, str] | None = None,
+    profile_path: Path | None = None,
+    state_path: Path | None = None,
+) -> ResolvedCliConfig:
+    """Resolve the effective CLI configuration using documented precedence."""
+    environment = dict(env or {})
+    profile = _load_profile(profile_path or default_profile_path())
+    state = _load_state(state_path or default_state_path())
+    profile_global = profile.get("global", {})
+
+    api_base_url, api_base_url_source = _resolve_api_base_url(
+        options,
+        environment,
+        profile_global,
+        state,
+    )
+    auth_token = _resolve_auth_token(options, environment, profile_global)
+    output = _coerce_output(
+        _first_non_none(
+            options.output,
+            environment.get("GHILLIE_OUTPUT"),
+            profile_global.get("output"),
+            "table",
+        )
+    )
+    log_level = _coerce_log_level(
+        _first_non_none(
+            options.log_level,
+            environment.get("GHILLIE_LOG_LEVEL"),
+            profile_global.get("log_level"),
+            "info",
+        )
+    )
+    request_timeout_s = _coerce_float(
+        _first_non_none(
+            options.request_timeout_s,
+            environment.get("GHILLIE_REQUEST_TIMEOUT_S"),
+            profile_global.get("request_timeout_s"),
+            30.0,
+        ),
+        field="request_timeout_s",
+    )
+    non_interactive = _coerce_bool(
+        _first_non_none(
+            options.non_interactive,
+            environment.get("GHILLIE_NON_INTERACTIVE"),
+            profile_global.get("non_interactive"),
+            _DEFAULT_NON_INTERACTIVE,
+        ),
+        field="non_interactive",
+    )
+    dry_run = _coerce_bool(
+        _first_non_none(
+            options.dry_run,
+            environment.get("GHILLIE_DRY_RUN"),
+            profile_global.get("dry_run"),
+            _DEFAULT_DRY_RUN,
+        ),
+        field="dry_run",
+    )
+
+    return ResolvedCliConfig(
+        api_base_url=api_base_url,
+        api_base_url_source=api_base_url_source,
+        auth_token=auth_token,
+        output=output,
+        log_level=log_level,
+        request_timeout_s=request_timeout_s,
+        non_interactive=non_interactive,
+        dry_run=dry_run,
+    )
+
+
+def _resolve_api_base_url(
+    options: GlobalOptions,
+    env: typ.Mapping[str, str],
+    profile_global: typ.Mapping[str, object],
+    state: typ.Mapping[str, object],
+) -> tuple[str, ApiBaseUrlSource]:
+    sources: tuple[tuple[ApiBaseUrlSource, object], ...] = (
+        ("flag", options.api_base_url),
+        ("env", env.get("GHILLIE_API_BASE_URL")),
+        ("profile", profile_global.get("api_base_url")),
+        ("state", state.get("api_base_url")),
+        ("fallback", _DEFAULT_API_BASE_URL),
+    )
+    for source, value in sources:
+        if value is None:
+            continue
+        return _validate_api_base_url(str(value)), source
+    return _DEFAULT_API_BASE_URL, "fallback"
+
+
+def _resolve_auth_token(
+    options: GlobalOptions,
+    env: typ.Mapping[str, str],
+    profile_global: typ.Mapping[str, object],
+) -> str | None:
+    if options.auth_token:
+        return options.auth_token
+    if env_token := env.get("GHILLIE_AUTH_TOKEN"):
+        return env_token
+    auth_token_env = profile_global.get("auth_token_env")
+    if isinstance(auth_token_env, str) and auth_token_env:
+        return env.get(auth_token_env)
+    return None
+
+
+def _load_profile(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {}
+    with path.open("rb") as file_obj:
+        content = tomllib.load(file_obj)
+    return content if isinstance(content, dict) else {}
+
+
+def _load_state(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_api_base_url(value: str) -> str:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        msg = f"api_base_url must be an absolute HTTP(S) URL: {value}"
+        raise ValueError(msg)
+    return value
+
+
+def _coerce_output(value: object) -> OutputFormat:
+    text = str(value)
+    if text not in _OUTPUT_VALUES:
+        msg = f"output must be one of: {', '.join(sorted(_OUTPUT_VALUES))}"
+        raise ValueError(msg)
+    return typ.cast("OutputFormat", text)
+
+
+def _coerce_log_level(value: object) -> LogLevel:
+    text = str(value)
+    if text not in _LOG_LEVEL_VALUES:
+        msg = f"log_level must be one of: {', '.join(sorted(_LOG_LEVEL_VALUES))}"
+        raise ValueError(msg)
+    return typ.cast("LogLevel", text)
+
+
+def _coerce_float(value: object, *, field: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        msg = f"{field} must be a float"
+        raise ValueError(msg) from exc
+
+
+def _coerce_bool(value: object, *, field: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    msg = f"{field} must be a boolean"
+    raise ValueError(msg)
+
+
+def _first_non_none(*values: object) -> object:
+    for value in values:
+        if value is not None:
+            return value
+    msg = "Expected at least one value"
+    raise ValueError(msg)

--- a/ghillie/cli/config.py
+++ b/ghillie/cli/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 OutputFormat = typ.Literal["table", "json", "yaml"]
-LogLevel = typ.Literal["debug", "info", "warn", "error"]
+CliLogLevel = typ.Literal["debug", "info", "warn", "error"]
 ApiBaseUrlSource = typ.Literal["flag", "env", "profile", "state", "fallback"]
 
 _OUTPUT_VALUES = {"table", "json", "yaml"}
@@ -27,7 +27,7 @@ class GlobalOptions:
     api_base_url: str | None = None
     auth_token: str | None = None
     output: OutputFormat | None = None
-    log_level: LogLevel | None = None
+    log_level: CliLogLevel | None = None
     request_timeout_s: float | None = None
     non_interactive: bool | None = None
     dry_run: bool | None = None
@@ -41,7 +41,7 @@ class ResolvedCliConfig:
     api_base_url_source: ApiBaseUrlSource
     auth_token: str | None
     output: OutputFormat
-    log_level: LogLevel
+    log_level: CliLogLevel
     request_timeout_s: float
     non_interactive: bool
     dry_run: bool
@@ -62,7 +62,7 @@ class _ScalarFields:
     """Intermediate scalar configuration fields."""
 
     output: OutputFormat
-    log_level: LogLevel
+    log_level: CliLogLevel
     request_timeout_s: float
     non_interactive: bool
     dry_run: bool
@@ -235,12 +235,12 @@ def _coerce_output(value: object) -> OutputFormat:
     return typ.cast("OutputFormat", text)
 
 
-def _coerce_log_level(value: object) -> LogLevel:
+def _coerce_log_level(value: object) -> CliLogLevel:
     text = str(value)
     if text not in _LOG_LEVEL_VALUES:
         msg = f"log_level must be one of: {', '.join(sorted(_LOG_LEVEL_VALUES))}"
         raise ValueError(msg)
-    return typ.cast("LogLevel", text)
+    return typ.cast("CliLogLevel", text)
 
 
 def _coerce_float(value: object, *, field: str) -> float:

--- a/ghillie/cli/config.py
+++ b/ghillie/cli/config.py
@@ -203,15 +203,23 @@ def _resolve_auth_token(
 def _load_profile(path: Path) -> dict[str, object]:
     if not path.exists():
         return {}
-    with path.open("rb") as file_obj:
-        content = tomllib.load(file_obj)
+    try:
+        with path.open("rb") as file_obj:
+            content = tomllib.load(file_obj)
+    except OSError as err:
+        msg = f"Failed to read profile from {path}"
+        raise ValueError(msg) from err
     return content if isinstance(content, dict) else {}
 
 
 def _load_state(path: Path) -> dict[str, object]:
     if not path.exists():
         return {}
-    content = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        content = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as err:
+        msg = f"Failed to read state from {path}"
+        raise ValueError(msg) from err
     if not isinstance(content, dict):
         type_name = type(content).__name__
         msg = f"state.json must contain a JSON object, found {type_name}"

--- a/ghillie/cli/config.py
+++ b/ghillie/cli/config.py
@@ -137,9 +137,7 @@ def resolve_cli_config(
     environment = dict(env or {})
     profile = _load_profile(profile_path or default_profile_path())
     state = _load_state(state_path or default_state_path())
-    profile_global = typ.cast(
-        typ.Mapping[str, object], profile.get("global", {})
-    )
+    profile_global = typ.cast("typ.Mapping[str, object]", profile.get("global", {}))
 
     api_base_url, api_base_url_source = _resolve_api_base_url(
         options,

--- a/ghillie/cli/config.py
+++ b/ghillie/cli/config.py
@@ -57,26 +57,23 @@ def default_state_path() -> Path:
     return Path.home() / ".config" / "ghillie" / "state.json"
 
 
-def resolve_cli_config(
-    options: GlobalOptions,
-    *,
-    env: typ.Mapping[str, str] | None = None,
-    profile_path: Path | None = None,
-    state_path: Path | None = None,
-) -> ResolvedCliConfig:
-    """Resolve the effective CLI configuration using documented precedence."""
-    environment = dict(env or {})
-    profile = _load_profile(profile_path or default_profile_path())
-    state = _load_state(state_path or default_state_path())
-    profile_global = profile.get("global", {})
+@dataclasses.dataclass(frozen=True, slots=True)
+class _ScalarFields:
+    """Intermediate scalar configuration fields."""
 
-    api_base_url, api_base_url_source = _resolve_api_base_url(
-        options,
-        environment,
-        profile_global,
-        state,
-    )
-    auth_token = _resolve_auth_token(options, environment, profile_global)
+    output: OutputFormat
+    log_level: LogLevel
+    request_timeout_s: float
+    non_interactive: bool
+    dry_run: bool
+
+
+def _resolve_scalar_fields(
+    options: GlobalOptions,
+    environment: typ.Mapping[str, str],
+    profile_global: typ.Mapping[str, object],
+) -> _ScalarFields:
+    """Resolve scalar configuration fields using documented precedence."""
     output = _coerce_output(
         _first_non_none(
             options.output,
@@ -120,16 +117,48 @@ def resolve_cli_config(
         ),
         field="dry_run",
     )
-
-    return ResolvedCliConfig(
-        api_base_url=api_base_url,
-        api_base_url_source=api_base_url_source,
-        auth_token=auth_token,
+    return _ScalarFields(
         output=output,
         log_level=log_level,
         request_timeout_s=request_timeout_s,
         non_interactive=non_interactive,
         dry_run=dry_run,
+    )
+
+
+def resolve_cli_config(
+    options: GlobalOptions,
+    *,
+    env: typ.Mapping[str, str] | None = None,
+    profile_path: Path | None = None,
+    state_path: Path | None = None,
+) -> ResolvedCliConfig:
+    """Resolve the effective CLI configuration using documented precedence."""
+    environment = dict(env or {})
+    profile = _load_profile(profile_path or default_profile_path())
+    state = _load_state(state_path or default_state_path())
+    profile_global = typ.cast(
+        typ.Mapping[str, object], profile.get("global", {})
+    )
+
+    api_base_url, api_base_url_source = _resolve_api_base_url(
+        options,
+        environment,
+        profile_global,
+        state,
+    )
+    auth_token = _resolve_auth_token(options, environment, profile_global)
+    scalars = _resolve_scalar_fields(options, environment, profile_global)
+
+    return ResolvedCliConfig(
+        api_base_url=api_base_url,
+        api_base_url_source=api_base_url_source,
+        auth_token=auth_token,
+        output=scalars.output,
+        log_level=scalars.log_level,
+        request_timeout_s=scalars.request_timeout_s,
+        non_interactive=scalars.non_interactive,
+        dry_run=scalars.dry_run,
     )
 
 
@@ -208,7 +237,7 @@ def _coerce_log_level(value: object) -> LogLevel:
 
 def _coerce_float(value: object, *, field: str) -> float:
     try:
-        return float(value)
+        return float(value)  # type: ignore[arg-type]
     except (TypeError, ValueError) as exc:
         msg = f"{field} must be a float"
         raise ValueError(msg) from exc

--- a/ghillie/cli/context.py
+++ b/ghillie/cli/context.py
@@ -34,7 +34,7 @@ def get_current_context() -> CommandContext:
 @contextlib.contextmanager
 def use_context(
     context: CommandContext,
-) -> typ.Generator[CommandContext, None, None]:
+) -> typ.Generator[CommandContext]:
     """Temporarily set the current command context."""
     token = _CURRENT_CONTEXT.set(context)
     try:

--- a/ghillie/cli/context.py
+++ b/ghillie/cli/context.py
@@ -1,0 +1,43 @@
+"""Per-invocation context for the packaged operator CLI."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import dataclasses
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from .config import ResolvedCliConfig
+
+_CURRENT_CONTEXT: contextvars.ContextVar[CommandContext | None] = (
+    contextvars.ContextVar("ghillie_cli_context", default=None)
+)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CommandContext:
+    """Shared resolved state for one CLI invocation."""
+
+    config: ResolvedCliConfig
+
+
+def get_current_context() -> CommandContext:
+    """Return the current command context or fail if none is active."""
+    context = _CURRENT_CONTEXT.get()
+    if context is None:
+        msg = "CLI command context has not been initialized"
+        raise RuntimeError(msg)
+    return context
+
+
+@contextlib.contextmanager
+def use_context(
+    context: CommandContext,
+) -> typ.Generator[CommandContext, None, None]:
+    """Temporarily set the current command context."""
+    token = _CURRENT_CONTEXT.set(context)
+    try:
+        yield context
+    finally:
+        _CURRENT_CONTEXT.reset(token)

--- a/ghillie/cli/context.py
+++ b/ghillie/cli/context.py
@@ -8,6 +8,8 @@ import dataclasses
 import typing as typ
 
 if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
     from .config import ResolvedCliConfig
 
 _CURRENT_CONTEXT: contextvars.ContextVar[CommandContext | None] = (
@@ -34,7 +36,7 @@ def get_current_context() -> CommandContext:
 @contextlib.contextmanager
 def use_context(
     context: CommandContext,
-) -> typ.Generator[CommandContext]:
+) -> cabc.Generator[CommandContext]:
     """Temporarily set the current command context."""
     token = _CURRENT_CONTEXT.set(context)
     try:

--- a/ghillie/cli/control_plane.py
+++ b/ghillie/cli/control_plane.py
@@ -11,7 +11,14 @@ if typ.TYPE_CHECKING:
 
 
 class ControlPlaneClient:
-    """Thin `httpx` wrapper configured from resolved CLI settings."""
+    """Thin `httpx` wrapper configured from resolved CLI settings.
+
+    Note:
+        When a custom ``http_client`` is provided, it is used directly and
+        must include the necessary ``User-Agent`` and ``Authorization`` headers.
+        Callers are responsible for ensuring custom clients are properly configured.
+
+    """
 
     def __init__(
         self,
@@ -19,7 +26,18 @@ class ControlPlaneClient:
         *,
         http_client: httpx.Client | None = None,
     ) -> None:
-        """Build a control-plane client from resolved CLI configuration."""
+        """Build a control-plane client from resolved CLI configuration.
+
+        Parameters
+        ----------
+        config
+            Resolved CLI configuration containing API URL, timeout, and auth.
+        http_client
+            Optional pre-configured httpx.Client. If provided, it must already
+            include appropriate ``User-Agent`` and ``Authorization`` headers.
+            If not provided, a new client will be created with these headers.
+
+        """
         self._owns_client = http_client is None
         self._http_client = http_client or httpx.Client(
             base_url=config.api_base_url,

--- a/ghillie/cli/control_plane.py
+++ b/ghillie/cli/control_plane.py
@@ -1,0 +1,53 @@
+"""HTTP control-plane client helpers for the operator CLI."""
+
+from __future__ import annotations
+
+import typing as typ
+
+import httpx
+
+if typ.TYPE_CHECKING:
+    from .config import ResolvedCliConfig
+
+
+class ControlPlaneClient:
+    """Thin `httpx` wrapper configured from resolved CLI settings."""
+
+    def __init__(
+        self,
+        config: ResolvedCliConfig,
+        *,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        """Build a control-plane client from resolved CLI configuration."""
+        self._owns_client = http_client is None
+        self._http_client = http_client or httpx.Client(
+            base_url=config.api_base_url,
+            timeout=config.request_timeout_s,
+            headers=_headers_for(config),
+        )
+
+    @property
+    def http_client(self) -> httpx.Client:
+        """Expose the underlying `httpx.Client` for higher-level commands."""
+        return self._http_client
+
+    def close(self) -> None:
+        """Close the owned HTTP client."""
+        if self._owns_client:
+            self._http_client.close()
+
+    def __enter__(self) -> ControlPlaneClient:
+        """Enter a context manager scope."""
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        """Close the client when leaving a context manager scope."""
+        self.close()
+
+
+def _headers_for(config: ResolvedCliConfig) -> dict[str, str]:
+    headers = {"User-Agent": "ghillie/0.1"}
+    if config.auth_token:
+        headers["Authorization"] = f"Bearer {config.auth_token}"
+    return headers

--- a/ghillie/cli/output.py
+++ b/ghillie/cli/output.py
@@ -1,0 +1,25 @@
+"""Output formatting helpers for operator CLI placeholders."""
+
+from __future__ import annotations
+
+import io
+import json
+import typing as typ
+
+from ruamel.yaml import YAML
+
+if typ.TYPE_CHECKING:
+    from .config import OutputFormat
+
+
+def render_output(payload: typ.Mapping[str, object], *, output: OutputFormat) -> str:
+    """Render one CLI payload according to the selected output format."""
+    if output == "json":
+        return json.dumps(payload, sort_keys=True)
+    if output == "yaml":
+        buffer = io.StringIO()
+        yaml = YAML(typ="safe")
+        yaml.default_flow_style = False
+        yaml.dump(dict(payload), buffer)
+        return buffer.getvalue().strip()
+    return "\n".join(f"{key}: {value}" for key, value in payload.items())

--- a/ghillie/cli/runtime_adapters.py
+++ b/ghillie/cli/runtime_adapters.py
@@ -31,9 +31,9 @@ class PythonApiRuntimeAdapter:
 def select_runtime_adapter(backend: RuntimeBackend) -> LocalRuntimeAdapter:
     """Select a local runtime adapter by the documented backend name."""
     match backend:
-        case "cuprum":
+        case RuntimeBackend.CUPRUM:
             return CuprumRuntimeAdapter()
-        case "python-api":
+        case RuntimeBackend.PYTHON_API:
             return PythonApiRuntimeAdapter()
         case _:
             msg = f"Unsupported runtime backend: {backend}"

--- a/ghillie/cli/runtime_adapters.py
+++ b/ghillie/cli/runtime_adapters.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 import typing as typ
 
-RuntimeBackend = typ.Literal["cuprum", "python-api"]
+from ghillie.cli.commands.params import RuntimeBackend
 
 
 class LocalRuntimeAdapter(typ.Protocol):
@@ -18,21 +18,23 @@ class LocalRuntimeAdapter(typ.Protocol):
 class CuprumRuntimeAdapter:
     """Placeholder adapter for shell-oriented local orchestration."""
 
-    name: RuntimeBackend = "cuprum"
+    name: RuntimeBackend = RuntimeBackend.CUPRUM
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class PythonApiRuntimeAdapter:
     """Placeholder adapter for direct Python integrations."""
 
-    name: RuntimeBackend = "python-api"
+    name: RuntimeBackend = RuntimeBackend.PYTHON_API
 
 
 def select_runtime_adapter(backend: RuntimeBackend) -> LocalRuntimeAdapter:
     """Select a local runtime adapter by the documented backend name."""
-    if backend == "cuprum":
-        return CuprumRuntimeAdapter()
-    if backend == "python-api":
-        return PythonApiRuntimeAdapter()
-    msg = f"Unsupported runtime backend: {backend}"
-    raise ValueError(msg)
+    match backend:
+        case "cuprum":
+            return CuprumRuntimeAdapter()
+        case "python-api":
+            return PythonApiRuntimeAdapter()
+        case _:
+            msg = f"Unsupported runtime backend: {backend}"
+            raise ValueError(msg)

--- a/ghillie/cli/runtime_adapters.py
+++ b/ghillie/cli/runtime_adapters.py
@@ -28,7 +28,7 @@ class PythonApiRuntimeAdapter:
     name: RuntimeBackend = "python-api"
 
 
-def select_runtime_adapter(backend: str) -> LocalRuntimeAdapter:
+def select_runtime_adapter(backend: RuntimeBackend) -> LocalRuntimeAdapter:
     """Select a local runtime adapter by the documented backend name."""
     if backend == "cuprum":
         return CuprumRuntimeAdapter()

--- a/ghillie/cli/runtime_adapters.py
+++ b/ghillie/cli/runtime_adapters.py
@@ -1,0 +1,38 @@
+"""Runtime adapter selection for local stack orchestration."""
+
+from __future__ import annotations
+
+import dataclasses
+import typing as typ
+
+RuntimeBackend = typ.Literal["cuprum", "python-api"]
+
+
+class LocalRuntimeAdapter(typ.Protocol):
+    """Protocol implemented by local runtime adapter placeholders."""
+
+    name: RuntimeBackend
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CuprumRuntimeAdapter:
+    """Placeholder adapter for shell-oriented local orchestration."""
+
+    name: RuntimeBackend = "cuprum"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PythonApiRuntimeAdapter:
+    """Placeholder adapter for direct Python integrations."""
+
+    name: RuntimeBackend = "python-api"
+
+
+def select_runtime_adapter(backend: str) -> LocalRuntimeAdapter:
+    """Select a local runtime adapter by the documented backend name."""
+    if backend == "cuprum":
+        return CuprumRuntimeAdapter()
+    if backend == "python-api":
+        return PythonApiRuntimeAdapter()
+    msg = f"Unsupported runtime backend: {backend}"
+    raise ValueError(msg)

--- a/ghillie/reporting/service.py
+++ b/ghillie/reporting/service.py
@@ -453,7 +453,7 @@ class ReportingService:
         model = self._get_model_identifier()
         attempt_count = self._config.validation_max_attempts
         validation_issues: list[ValidationIssuePayload] = [
-            {"code": issue.code, "message": issue.message}
+            ValidationIssuePayload(code=issue.code, message=issue.message)
             for issue in validation.issues
         ]
         review = ReportReview(

--- a/ghillie/status/openai_client.py
+++ b/ghillie/status/openai_client.py
@@ -55,7 +55,7 @@ def _get_nested(data: JSONLike, *keys: str) -> object | None:
     for key in keys:
         if not _is_object_dict(current):
             return None
-        current = current.get(key)
+        current = typ.cast("dict[str, object]", current).get(key)
     return current
 
 

--- a/ghillie/status/openai_client.py
+++ b/ghillie/status/openai_client.py
@@ -55,7 +55,7 @@ def _get_nested(data: JSONLike, *keys: str) -> object | None:
     for key in keys:
         if not _is_object_dict(current):
             return None
-        current = typ.cast("dict[str, object]", current).get(key)
+        current = current.get(key)
     return current
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,11 @@ dependencies = [
     "httpx>=0.27.0",
     "falcon>=4.0.0,<5.0.0",
     "granian>=1.0.0,<3.0.0",
+    "cyclopts>=2.9,<3",
 ]
+
+[project.scripts]
+ghillie = "ghillie.cli:main"
 
 [dependency-groups]
 dev = [
@@ -40,7 +44,6 @@ dev = [
     "ty>=0.0.1a21",
     "pytest-timeout",
     # Script dependencies for type checking and testing
-    "cyclopts>=2.9,<3",
     "plumbum>=1.10,<2",
     "cmd-mox>=0.2,<1",
 ]

--- a/scripts/local_k8s/config.py
+++ b/scripts/local_k8s/config.py
@@ -65,7 +65,7 @@ class Config:
     app_secret_name: str = ""
 
     def __post_init__(self) -> None:
-        """Default derived fields after initialization."""
+        """Populate derived fields after initialization."""
         if not self.app_secret_name:
             object.__setattr__(self, "app_secret_name", self.app_name)
 

--- a/tests/features/operator_cli_contract.feature
+++ b/tests/features/operator_cli_contract.feature
@@ -1,0 +1,33 @@
+Feature: Operator CLI contract
+
+  The packaged operator CLI should expose the MVP noun and verb grammar
+  and validate the documented option surface before later tasks add
+  real backend behaviour.
+
+  Scenario: Root help lists the top-level nouns
+    When I run the operator CLI with "--help"
+    Then the operator CLI exits with code 0
+    And the operator CLI output mentions "stack"
+    And the operator CLI output mentions "estate"
+    And the operator CLI output mentions "ingest"
+    And the operator CLI output mentions "export"
+    And the operator CLI output mentions "report"
+    And the operator CLI output mentions "metrics"
+
+  Scenario: Stack up help exposes backend and wait options
+    When I run the operator CLI with "stack up --help"
+    Then the operator CLI exits with code 0
+    And the operator CLI output mentions "--backend"
+    And the operator CLI output mentions "--wait"
+    And the operator CLI output mentions "--no-wait"
+
+  Scenario: Root global options parse before the noun command
+    When I run the operator CLI with "--api-base-url http://127.0.0.1:9999 report run --help"
+    Then the operator CLI exits with code 0
+    And the operator CLI output mentions "Usage"
+    And the operator CLI output mentions "--scope"
+
+  Scenario: Invalid stack backend fails fast
+    When I run the operator CLI with "stack up --backend invalid"
+    Then the operator CLI exits with code 2
+    And the operator CLI error mentions "invalid choice"

--- a/tests/features/operator_cli_contract.feature
+++ b/tests/features/operator_cli_contract.feature
@@ -31,3 +31,23 @@ Feature: Operator CLI contract
     When I run the operator CLI with "stack up --backend invalid"
     Then the operator CLI exits with code 2
     And the operator CLI error mentions "invalid choice"
+
+  Scenario: GHILLIE_BACKEND environment variable sets default backend
+    Given the environment variable "GHILLIE_BACKEND" is set to "python-api"
+    When I run the operator CLI with "stack up"
+    Then the operator CLI exits with code 0
+    And the operator CLI output mentions "python-api"
+
+  Scenario: GHILLIE_PROFILE environment variable sets default profile
+    Given the environment variable "GHILLIE_PROFILE" is set to "reporting-worker"
+    When I run the operator CLI with "stack up"
+    Then the operator CLI exits with code 0
+    And the operator CLI output mentions "reporting-worker"
+
+  Scenario: Explicit stack options override environment defaults
+    Given the environment variable "GHILLIE_BACKEND" is set to "python-api"
+    And the environment variable "GHILLIE_PROFILE" is set to "reporting-worker"
+    When I run the operator CLI with "stack up --backend cuprum --profile api-only"
+    Then the operator CLI exits with code 0
+    And the operator CLI output mentions "cuprum"
+    And the operator CLI output mentions "api-only"

--- a/tests/features/steps/test_catalogue_steps.py
+++ b/tests/features/steps/test_catalogue_steps.py
@@ -156,8 +156,7 @@ def schema_validation(context: StepContext, tmp_path: Path) -> None:
             "pajv must be installed for behavioural schema validation; "
             "unit tests skip this when the binary is absent"
         )
-    else:
-        assert pajv_path is not None
+    assert pajv_path is not None
 
     schema_path = tmp_path / "catalogue.schema.json"
     write_catalogue_schema(schema_path)
@@ -169,8 +168,6 @@ def schema_validation(context: StepContext, tmp_path: Path) -> None:
 
     try:
         subprocess.run(  # noqa: S603 - static pajv invocation
-            # pyright/mypy overloads lack a variant with stdout/stderr pipes + text=True
-            # for CompletedProcess[str]; this call is valid at runtime.
             [
                 pajv_path,
                 "-s",
@@ -180,7 +177,6 @@ def schema_validation(context: StepContext, tmp_path: Path) -> None:
             ],
             check=True,
             capture_output=True,
-            text=True,
             encoding="utf-8",
         )
     except subprocess.CalledProcessError as exc:

--- a/tests/features/steps/test_operator_cli_steps.py
+++ b/tests/features/steps/test_operator_cli_steps.py
@@ -1,0 +1,102 @@
+"""Behavioural coverage for the packaged operator CLI contract."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import shlex
+import typing as typ
+
+import pytest
+from pytest_bdd import parsers, scenario, then, when
+
+from ghillie.cli import main
+
+
+class OperatorCliContext(typ.TypedDict, total=False):
+    """Shared mutable scenario state for CLI behaviour tests."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+@scenario(
+    "../operator_cli_contract.feature",
+    "Root help lists the top-level nouns",
+)
+def test_root_help_lists_top_level_nouns() -> None:
+    """Wrap the root-help scenario."""
+
+
+@scenario(
+    "../operator_cli_contract.feature",
+    "Stack up help exposes backend and wait options",
+)
+def test_stack_up_help_exposes_backend_and_wait_options() -> None:
+    """Wrap the stack help scenario."""
+
+
+@scenario(
+    "../operator_cli_contract.feature",
+    "Root global options parse before the noun command",
+)
+def test_root_global_options_parse_before_the_noun_command() -> None:
+    """Wrap the global-options scenario."""
+
+
+@scenario(
+    "../operator_cli_contract.feature",
+    "Invalid stack backend fails fast",
+)
+def test_invalid_stack_backend_fails_fast() -> None:
+    """Wrap the invalid-backend scenario."""
+
+
+@pytest.fixture
+def operator_cli_context() -> OperatorCliContext:
+    """Create mutable scenario state for a CLI invocation."""
+    return {}
+
+
+@when(parsers.parse('I run the operator CLI with "{arguments}"'))
+def when_run_operator_cli(
+    operator_cli_context: OperatorCliContext, arguments: str
+) -> None:
+    """Invoke the operator CLI and capture its stdout and stderr streams."""
+    argv = shlex.split(arguments)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with (
+        contextlib.redirect_stdout(stdout),
+        contextlib.redirect_stderr(stderr),
+    ):
+        exit_code = main(argv)
+
+    operator_cli_context["exit_code"] = exit_code
+    operator_cli_context["stdout"] = stdout.getvalue()
+    operator_cli_context["stderr"] = stderr.getvalue()
+
+
+@then(parsers.parse("the operator CLI exits with code {expected:d}"))
+def then_operator_cli_exit_code(
+    operator_cli_context: OperatorCliContext, expected: int
+) -> None:
+    """Assert the CLI exit code for the current scenario."""
+    assert operator_cli_context["exit_code"] == expected
+
+
+@then(parsers.parse('the operator CLI output mentions "{expected}"'))
+def then_operator_cli_output_mentions(
+    operator_cli_context: OperatorCliContext, expected: str
+) -> None:
+    """Assert the CLI stdout stream contains the expected fragment."""
+    assert expected in operator_cli_context["stdout"]
+
+
+@then(parsers.parse('the operator CLI error mentions "{expected}"'))
+def then_operator_cli_error_mentions(
+    operator_cli_context: OperatorCliContext, expected: str
+) -> None:
+    """Assert the CLI stderr stream contains the expected fragment."""
+    assert expected in operator_cli_context["stderr"]

--- a/tests/features/steps/test_operator_cli_steps.py
+++ b/tests/features/steps/test_operator_cli_steps.py
@@ -122,7 +122,8 @@ def then_operator_cli_exit_code(
     operator_cli_context: OperatorCliContext, expected: int
 ) -> None:
     """Assert the CLI exit code for the current scenario."""
-    assert operator_cli_context["exit_code"] == expected
+    actual = operator_cli_context["exit_code"]
+    assert actual == expected, f"Expected exit code {expected}, got {actual}"
 
 
 @then(parsers.parse('the operator CLI output mentions "{expected}"'))
@@ -130,7 +131,8 @@ def then_operator_cli_output_mentions(
     operator_cli_context: OperatorCliContext, expected: str
 ) -> None:
     """Assert the CLI stdout stream contains the expected fragment."""
-    assert expected in operator_cli_context["stdout"]
+    stdout = operator_cli_context["stdout"]
+    assert expected in stdout, f'Expected "{expected}" in stdout, got: {stdout!r}'
 
 
 @then(parsers.parse('the operator CLI error mentions "{expected}"'))
@@ -138,4 +140,5 @@ def then_operator_cli_error_mentions(
     operator_cli_context: OperatorCliContext, expected: str
 ) -> None:
     """Assert the CLI stderr stream contains the expected fragment."""
-    assert expected in operator_cli_context["stderr"]
+    stderr = operator_cli_context["stderr"]
+    assert expected in stderr, f'Expected "{expected}" in stderr, got: {stderr!r}'

--- a/tests/features/steps/test_operator_cli_steps.py
+++ b/tests/features/steps/test_operator_cli_steps.py
@@ -8,7 +8,7 @@ import shlex
 import typing as typ
 
 import pytest
-from pytest_bdd import parsers, scenario, then, when
+from pytest_bdd import given, parsers, scenario, then, when
 
 from ghillie.cli import main
 
@@ -19,6 +19,7 @@ class OperatorCliContext(typ.TypedDict, total=False):
     exit_code: int
     stdout: str
     stderr: str
+    env: dict[str, str]
 
 
 @scenario(
@@ -53,17 +54,55 @@ def test_invalid_stack_backend_fails_fast() -> None:
     """Wrap the invalid-backend scenario."""
 
 
+@scenario(
+    "../operator_cli_contract.feature",
+    "GHILLIE_BACKEND environment variable sets default backend",
+)
+def test_ghillie_backend_env_var_sets_default() -> None:
+    """Wrap the GHILLIE_BACKEND environment variable scenario."""
+
+
+@scenario(
+    "../operator_cli_contract.feature",
+    "GHILLIE_PROFILE environment variable sets default profile",
+)
+def test_ghillie_profile_env_var_sets_default() -> None:
+    """Wrap the GHILLIE_PROFILE environment variable scenario."""
+
+
+@scenario(
+    "../operator_cli_contract.feature",
+    "Explicit stack options override environment defaults",
+)
+def test_explicit_options_override_env_defaults() -> None:
+    """Wrap the explicit override scenario."""
+
+
 @pytest.fixture
 def operator_cli_context() -> OperatorCliContext:
     """Create mutable scenario state for a CLI invocation."""
-    return {}
+    return {"env": {}}
+
+
+@given(parsers.parse('the environment variable "{key}" is set to "{value}"'))
+def given_environment_variable(
+    operator_cli_context: OperatorCliContext, key: str, value: str
+) -> None:
+    """Set an environment variable for the CLI invocation."""
+    operator_cli_context["env"][key] = value
 
 
 @when(parsers.parse('I run the operator CLI with "{arguments}"'))
 def when_run_operator_cli(
-    operator_cli_context: OperatorCliContext, arguments: str
+    operator_cli_context: OperatorCliContext,
+    arguments: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Invoke the operator CLI and capture its stdout and stderr streams."""
+    # Apply environment variables
+    for key, value in operator_cli_context.get("env", {}).items():
+        monkeypatch.setenv(key, value)
+
     argv = shlex.split(arguments)
     stdout = io.StringIO()
     stderr = io.StringIO()

--- a/tests/unit/cli/__init__.py
+++ b/tests/unit/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the packaged operator CLI."""

--- a/tests/unit/cli/test_app.py
+++ b/tests/unit/cli/test_app.py
@@ -1,0 +1,59 @@
+"""Unit tests for the operator CLI command tree."""
+
+from __future__ import annotations
+
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from cyclopts import App
+
+from ghillie.cli.app import app
+
+
+def _command_names(command_app: App) -> set[str]:
+    return {
+        str(item)
+        for item in command_app
+        if isinstance(item, str) and not item.startswith("-")
+    }
+
+
+def test_app_has_expected_name() -> None:
+    """The packaged CLI should present itself as `ghillie`."""
+    assert app.name == ("ghillie",)
+
+
+def test_app_has_expected_root_nouns() -> None:
+    """The root noun set should match the MVP CLI contract exactly."""
+    assert _command_names(app) == {
+        "estate",
+        "export",
+        "ingest",
+        "metrics",
+        "report",
+        "stack",
+    }
+
+
+def test_stack_noun_has_expected_verbs() -> None:
+    """The stack noun should expose the documented lifecycle verbs."""
+    assert _command_names(app["stack"]) == {"down", "logs", "status", "up"}
+
+
+def test_estate_noun_has_expected_verbs_and_repo_group() -> None:
+    """The estate noun should include direct verbs and the nested repo group."""
+    assert _command_names(app["estate"]) == {"import", "list", "repo", "sync"}
+    assert _command_names(app["estate"]["repo"]) == {"list", "set"}
+
+
+def test_other_nouns_have_expected_verbs() -> None:
+    """The remaining nouns should match the documented verbs."""
+    assert _command_names(app["ingest"]) == {"run", "status", "watch"}
+    assert _command_names(app["export"]) == {
+        "bundle",
+        "events",
+        "evidence",
+        "reports",
+    }
+    assert _command_names(app["report"]) == {"run", "status", "watch"}
+    assert _command_names(app["metrics"]) == {"nice", "required"}

--- a/tests/unit/cli/test_config_resolution.py
+++ b/tests/unit/cli/test_config_resolution.py
@@ -133,13 +133,13 @@ def test_config_uses_state_then_fallback_when_higher_sources_absent(
         pytest.param(
             GlobalOptions(),
             {"GHILLIE_NON_INTERACTIVE": "definitely-not-a-bool"},
-            r"non_interactive|dry_run",
+            r"non_interactive",
             id="invalid_non_interactive_env",
         ),
         pytest.param(
             GlobalOptions(),
             {"GHILLIE_DRY_RUN": "definitely-not-a-bool"},
-            r"non_interactive|dry_run",
+            r"dry_run",
             id="invalid_dry_run_env",
         ),
     ],

--- a/tests/unit/cli/test_config_resolution.py
+++ b/tests/unit/cli/test_config_resolution.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import typing as typ
 
+import pytest
+
 if typ.TYPE_CHECKING:
     from pathlib import Path
 
@@ -93,3 +95,149 @@ def test_config_uses_state_then_fallback_when_higher_sources_absent(
     assert from_state.api_base_url_source == "state"
     assert from_fallback.api_base_url == "http://127.0.0.1:8080"
     assert from_fallback.api_base_url_source == "fallback"
+
+
+def test_config_invalid_api_base_url_scheme_raises_value_error(tmp_path: Path) -> None:
+    """Non-HTTP(S) API URLs should be rejected."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+
+    with pytest.raises(ValueError, match="api_base_url"):
+        resolve_cli_config(
+            GlobalOptions(api_base_url="ftp://example.com"),
+            env={},
+            profile_path=profile_path,
+            state_path=state_path,
+        )
+
+
+def test_config_invalid_api_base_url_missing_netloc_raises_value_error(
+    tmp_path: Path,
+) -> None:
+    """API URLs without netloc should be rejected."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+
+    with pytest.raises(ValueError, match="api_base_url"):
+        resolve_cli_config(
+            GlobalOptions(api_base_url="http://"),
+            env={},
+            profile_path=profile_path,
+            state_path=state_path,
+        )
+
+
+def test_config_invalid_request_timeout_env_raises_value_error(tmp_path: Path) -> None:
+    """Non-numeric GHILLIE_REQUEST_TIMEOUT_S should raise ValueError."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+
+    with pytest.raises(ValueError, match="request_timeout_s"):
+        resolve_cli_config(
+            GlobalOptions(),
+            env={"GHILLIE_REQUEST_TIMEOUT_S": "abc"},
+            profile_path=profile_path,
+            state_path=state_path,
+        )
+
+
+def test_config_invalid_output_env_raises_value_error(tmp_path: Path) -> None:
+    """Invalid GHILLIE_OUTPUT should raise ValueError."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+
+    with pytest.raises(ValueError, match="output"):
+        resolve_cli_config(
+            GlobalOptions(),
+            env={"GHILLIE_OUTPUT": "xml"},
+            profile_path=profile_path,
+            state_path=state_path,
+        )
+
+
+def test_config_invalid_log_level_env_raises_value_error(tmp_path: Path) -> None:
+    """Invalid GHILLIE_LOG_LEVEL should raise ValueError."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+
+    with pytest.raises(ValueError, match="log_level"):
+        resolve_cli_config(
+            GlobalOptions(),
+            env={"GHILLIE_LOG_LEVEL": "verbose"},
+            profile_path=profile_path,
+            state_path=state_path,
+        )
+
+
+@pytest.mark.parametrize(
+    "env_key",
+    [
+        "GHILLIE_NON_INTERACTIVE",
+        "GHILLIE_DRY_RUN",
+    ],
+)
+def test_config_invalid_bool_env_raises_value_error(
+    tmp_path: Path, env_key: str
+) -> None:
+    """Non-boolean toggles in env should raise ValueError."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+
+    with pytest.raises(ValueError, match=r"non_interactive|dry_run"):
+        resolve_cli_config(
+            GlobalOptions(),
+            env={env_key: "definitely-not-a-bool"},
+            profile_path=profile_path,
+            state_path=state_path,
+        )
+
+
+def test_config_auth_token_resolution_with_missing_env_var(tmp_path: Path) -> None:
+    """When auth_token_env points to unset env var, auth_token should be None."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+    profile_path.write_text(
+        """
+[global]
+auth_token_env = "MISSING_TOKEN"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    config = resolve_cli_config(
+        GlobalOptions(),
+        env={},
+        profile_path=profile_path,
+        state_path=state_path,
+    )
+
+    assert config.auth_token is None
+
+
+def test_config_direct_auth_token_flag_overrides_env_and_profile(
+    tmp_path: Path,
+) -> None:
+    """Direct auth_token flag overrides GHILLIE_AUTH_TOKEN and auth_token_env."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+    profile_path.write_text(
+        """
+[global]
+auth_token_env = "PROFILE_TOKEN"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    config = resolve_cli_config(
+        GlobalOptions(auth_token="flag-token"),  # noqa: S106
+        env={
+            "GHILLIE_AUTH_TOKEN": "env-token",
+            "PROFILE_TOKEN": "profile-env-token",
+        },
+        profile_path=profile_path,
+        state_path=state_path,
+    )
+
+    assert config.auth_token == "flag-token"  # noqa: S105

--- a/tests/unit/cli/test_config_resolution.py
+++ b/tests/unit/cli/test_config_resolution.py
@@ -1,0 +1,95 @@
+"""Unit tests for CLI configuration precedence."""
+
+from __future__ import annotations
+
+import json
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+from ghillie.cli.config import GlobalOptions, resolve_cli_config
+
+
+def _write_profile(path: Path) -> None:
+    path.write_text(
+        """
+[global]
+api_base_url = "http://127.0.0.1:7000"
+auth_token_env = "PROFILE_AUTH_TOKEN"
+output = "yaml"
+log_level = "warn"
+request_timeout_s = 18.5
+non_interactive = true
+dry_run = false
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_state(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "api_base_url": "http://127.0.0.1:7100",
+                "source": "stack_up",
+                "updated_at": "2026-03-14T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_config_precedence_is_flag_env_profile_state_then_fallback(
+    tmp_path: Path,
+) -> None:
+    """The documented precedence order should resolve the effective API URL."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+    _write_profile(profile_path)
+    _write_state(state_path)
+
+    config = resolve_cli_config(
+        GlobalOptions(api_base_url="http://127.0.0.1:7200"),
+        env={
+            "GHILLIE_API_BASE_URL": "http://127.0.0.1:7300",
+            "GHILLIE_OUTPUT": "json",
+            "PROFILE_AUTH_TOKEN": "profile-token",
+        },
+        profile_path=profile_path,
+        state_path=state_path,
+    )
+
+    assert config.api_base_url == "http://127.0.0.1:7200"
+    assert config.api_base_url_source == "flag"
+    assert config.output == "json"
+    assert config.auth_token == "profile-token"  # noqa: S105
+    assert config.log_level == "warn"
+    assert config.request_timeout_s == 18.5
+
+
+def test_config_uses_state_then_fallback_when_higher_sources_absent(
+    tmp_path: Path,
+) -> None:
+    """Persisted runtime state should beat fallback when no higher source exists."""
+    state_path = tmp_path / "state.json"
+    _write_state(state_path)
+
+    from_state = resolve_cli_config(
+        GlobalOptions(),
+        env={},
+        profile_path=tmp_path / "missing.toml",
+        state_path=state_path,
+    )
+    from_fallback = resolve_cli_config(
+        GlobalOptions(),
+        env={},
+        profile_path=tmp_path / "missing.toml",
+        state_path=tmp_path / "missing.json",
+    )
+
+    assert from_state.api_base_url == "http://127.0.0.1:7100"
+    assert from_state.api_base_url_source == "state"
+    assert from_fallback.api_base_url == "http://127.0.0.1:8080"
+    assert from_fallback.api_base_url_source == "fallback"

--- a/tests/unit/cli/test_config_resolution.py
+++ b/tests/unit/cli/test_config_resolution.py
@@ -241,3 +241,36 @@ auth_token_env = "PROFILE_TOKEN"
     )
 
     assert config.auth_token == "flag-token"  # noqa: S105
+
+
+def test_config_rejects_non_object_state_json(tmp_path: Path) -> None:
+    """Non-object state.json should raise TypeError instead of crashing."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+    state_path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(TypeError, match=r"state\.json must contain a JSON object"):
+        resolve_cli_config(
+            GlobalOptions(),
+            env={},
+            profile_path=profile_path,
+            state_path=state_path,
+        )
+
+
+def test_config_rejects_non_table_global_section(tmp_path: Path) -> None:
+    """Non-table [global] section should raise TypeError instead of crashing."""
+    profile_path = tmp_path / "cli.toml"
+    state_path = tmp_path / "state.json"
+    profile_path.write_text(
+        'global = "oops"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match=r"\[global\] section.*must be a table"):
+        resolve_cli_config(
+            GlobalOptions(),
+            env={},
+            profile_path=profile_path,
+            state_path=state_path,
+        )

--- a/tests/unit/cli/test_config_resolution.py
+++ b/tests/unit/cli/test_config_resolution.py
@@ -97,98 +97,66 @@ def test_config_uses_state_then_fallback_when_higher_sources_absent(
     assert from_fallback.api_base_url_source == "fallback"
 
 
-def test_config_invalid_api_base_url_scheme_raises_value_error(tmp_path: Path) -> None:
-    """Non-HTTP(S) API URLs should be rejected."""
-    profile_path = tmp_path / "cli.toml"
-    state_path = tmp_path / "state.json"
-
-    with pytest.raises(ValueError, match="api_base_url"):
-        resolve_cli_config(
-            GlobalOptions(api_base_url="ftp://example.com"),
-            env={},
-            profile_path=profile_path,
-            state_path=state_path,
-        )
-
-
-def test_config_invalid_api_base_url_missing_netloc_raises_value_error(
-    tmp_path: Path,
-) -> None:
-    """API URLs without netloc should be rejected."""
-    profile_path = tmp_path / "cli.toml"
-    state_path = tmp_path / "state.json"
-
-    with pytest.raises(ValueError, match="api_base_url"):
-        resolve_cli_config(
-            GlobalOptions(api_base_url="http://"),
-            env={},
-            profile_path=profile_path,
-            state_path=state_path,
-        )
-
-
-def test_config_invalid_request_timeout_env_raises_value_error(tmp_path: Path) -> None:
-    """Non-numeric GHILLIE_REQUEST_TIMEOUT_S should raise ValueError."""
-    profile_path = tmp_path / "cli.toml"
-    state_path = tmp_path / "state.json"
-
-    with pytest.raises(ValueError, match="request_timeout_s"):
-        resolve_cli_config(
-            GlobalOptions(),
-            env={"GHILLIE_REQUEST_TIMEOUT_S": "abc"},
-            profile_path=profile_path,
-            state_path=state_path,
-        )
-
-
-def test_config_invalid_output_env_raises_value_error(tmp_path: Path) -> None:
-    """Invalid GHILLIE_OUTPUT should raise ValueError."""
-    profile_path = tmp_path / "cli.toml"
-    state_path = tmp_path / "state.json"
-
-    with pytest.raises(ValueError, match="output"):
-        resolve_cli_config(
-            GlobalOptions(),
-            env={"GHILLIE_OUTPUT": "xml"},
-            profile_path=profile_path,
-            state_path=state_path,
-        )
-
-
-def test_config_invalid_log_level_env_raises_value_error(tmp_path: Path) -> None:
-    """Invalid GHILLIE_LOG_LEVEL should raise ValueError."""
-    profile_path = tmp_path / "cli.toml"
-    state_path = tmp_path / "state.json"
-
-    with pytest.raises(ValueError, match="log_level"):
-        resolve_cli_config(
-            GlobalOptions(),
-            env={"GHILLIE_LOG_LEVEL": "verbose"},
-            profile_path=profile_path,
-            state_path=state_path,
-        )
-
-
 @pytest.mark.parametrize(
-    "env_key",
+    ("options", "env", "match"),
     [
-        "GHILLIE_NON_INTERACTIVE",
-        "GHILLIE_DRY_RUN",
+        pytest.param(
+            GlobalOptions(api_base_url="ftp://example.com"),
+            {},
+            "api_base_url",
+            id="invalid_scheme",
+        ),
+        pytest.param(
+            GlobalOptions(api_base_url="http://"),
+            {},
+            "api_base_url",
+            id="missing_netloc",
+        ),
+        pytest.param(
+            GlobalOptions(),
+            {"GHILLIE_REQUEST_TIMEOUT_S": "abc"},
+            "request_timeout_s",
+            id="invalid_request_timeout_env",
+        ),
+        pytest.param(
+            GlobalOptions(),
+            {"GHILLIE_OUTPUT": "xml"},
+            "output",
+            id="invalid_output_env",
+        ),
+        pytest.param(
+            GlobalOptions(),
+            {"GHILLIE_LOG_LEVEL": "verbose"},
+            "log_level",
+            id="invalid_log_level_env",
+        ),
+        pytest.param(
+            GlobalOptions(),
+            {"GHILLIE_NON_INTERACTIVE": "definitely-not-a-bool"},
+            r"non_interactive|dry_run",
+            id="invalid_non_interactive_env",
+        ),
+        pytest.param(
+            GlobalOptions(),
+            {"GHILLIE_DRY_RUN": "definitely-not-a-bool"},
+            r"non_interactive|dry_run",
+            id="invalid_dry_run_env",
+        ),
     ],
 )
-def test_config_invalid_bool_env_raises_value_error(
-    tmp_path: Path, env_key: str
+def test_config_invalid_value_raises_value_error(
+    tmp_path: Path,
+    options: GlobalOptions,
+    env: dict[str, str],
+    match: str,
 ) -> None:
-    """Non-boolean toggles in env should raise ValueError."""
-    profile_path = tmp_path / "cli.toml"
-    state_path = tmp_path / "state.json"
-
-    with pytest.raises(ValueError, match=r"non_interactive|dry_run"):
+    """Invalid configuration values should raise ValueError."""
+    with pytest.raises(ValueError, match=match):
         resolve_cli_config(
-            GlobalOptions(),
-            env={env_key: "definitely-not-a-bool"},
-            profile_path=profile_path,
-            state_path=state_path,
+            options,
+            env=env,
+            profile_path=tmp_path / "cli.toml",
+            state_path=tmp_path / "state.json",
         )
 
 
@@ -243,31 +211,38 @@ auth_token_env = "PROFILE_TOKEN"
     assert config.auth_token == "flag-token"  # noqa: S105
 
 
-def test_config_rejects_non_object_state_json(tmp_path: Path) -> None:
-    """Non-object state.json should raise TypeError instead of crashing."""
+@pytest.mark.parametrize(
+    ("state_content", "profile_content", "match"),
+    [
+        pytest.param(
+            "[]",
+            None,
+            r"state\.json must contain a JSON object",
+            id="non_object_state_json",
+        ),
+        pytest.param(
+            None,
+            'global = "oops"\n',
+            r"\[global\] section.*must be a table",
+            id="non_table_global_section",
+        ),
+    ],
+)
+def test_config_invalid_file_content_raises_type_error(
+    tmp_path: Path,
+    state_content: str | None,
+    profile_content: str | None,
+    match: str,
+) -> None:
+    """Malformed profile or state file content should raise TypeError."""
     profile_path = tmp_path / "cli.toml"
     state_path = tmp_path / "state.json"
-    state_path.write_text("[]", encoding="utf-8")
+    if state_content is not None:
+        state_path.write_text(state_content, encoding="utf-8")
+    if profile_content is not None:
+        profile_path.write_text(profile_content, encoding="utf-8")
 
-    with pytest.raises(TypeError, match=r"state\.json must contain a JSON object"):
-        resolve_cli_config(
-            GlobalOptions(),
-            env={},
-            profile_path=profile_path,
-            state_path=state_path,
-        )
-
-
-def test_config_rejects_non_table_global_section(tmp_path: Path) -> None:
-    """Non-table [global] section should raise TypeError instead of crashing."""
-    profile_path = tmp_path / "cli.toml"
-    state_path = tmp_path / "state.json"
-    profile_path.write_text(
-        'global = "oops"\n',
-        encoding="utf-8",
-    )
-
-    with pytest.raises(TypeError, match=r"\[global\] section.*must be a table"):
+    with pytest.raises(TypeError, match=match):
         resolve_cli_config(
             GlobalOptions(),
             env={},

--- a/tests/unit/cli/test_context.py
+++ b/tests/unit/cli/test_context.py
@@ -8,6 +8,8 @@ import pytest
 
 from ghillie.cli.context import CommandContext, get_current_context, use_context
 
+_TEST_AUTH_TOKEN = "test-token"  # noqa: S105  # nosec B105 - test fixture value only
+
 
 def test_get_current_context_without_active_context_raises() -> None:
     """get_current_context() should raise when no context has been set."""
@@ -36,7 +38,7 @@ def test_use_context_sets_and_restores_context() -> None:
         config=ResolvedCliConfig(
             api_base_url="http://127.0.0.1:9999",
             api_base_url_source="flag",
-            auth_token="token",  # noqa: S106
+            auth_token=_TEST_AUTH_TOKEN,
             output="json",
             log_level="debug",
             request_timeout_s=10.0,
@@ -57,7 +59,7 @@ def test_use_context_sets_and_restores_context() -> None:
         assert get_current_context() is base_ctx
 
     # After exiting outer context, there should be no active context
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="CLI command context"):
         get_current_context()
 
 
@@ -105,7 +107,7 @@ def test_use_context_restores_context_on_exception() -> None:
         assert get_current_context() is outer_ctx
 
     # No active context after exiting outer block
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="CLI command context"):
         get_current_context()
 
 
@@ -161,5 +163,5 @@ def test_use_context_is_reentrant_and_nestable() -> None:
         assert get_current_context() is ctx3
 
     # After all are closed, there should be no active context
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="CLI command context"):
         get_current_context()

--- a/tests/unit/cli/test_context.py
+++ b/tests/unit/cli/test_context.py
@@ -1,0 +1,165 @@
+"""Unit tests for CLI context helpers."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+
+import pytest
+
+from ghillie.cli.context import CommandContext, get_current_context, use_context
+
+
+def test_get_current_context_without_active_context_raises() -> None:
+    """get_current_context() should raise when no context has been set."""
+    # Ensure there's no active context by not using use_context()
+    with pytest.raises(RuntimeError, match="CLI command context"):
+        get_current_context()
+
+
+def test_use_context_sets_and_restores_context() -> None:
+    """use_context should set and restore context inside and after its block."""
+    from ghillie.cli.config import ResolvedCliConfig
+
+    base_ctx = CommandContext(
+        config=ResolvedCliConfig(
+            api_base_url="http://127.0.0.1:8080",
+            api_base_url_source="fallback",
+            auth_token=None,
+            output="table",
+            log_level="info",
+            request_timeout_s=30.0,
+            non_interactive=True,
+            dry_run=False,
+        )
+    )
+    nested_ctx = CommandContext(
+        config=ResolvedCliConfig(
+            api_base_url="http://127.0.0.1:9999",
+            api_base_url_source="flag",
+            auth_token="token",  # noqa: S106
+            output="json",
+            log_level="debug",
+            request_timeout_s=10.0,
+            non_interactive=False,
+            dry_run=True,
+        )
+    )
+
+    # Establish an initial context
+    with use_context(base_ctx):
+        assert get_current_context() is base_ctx
+
+        # Replace with a nested context
+        with use_context(nested_ctx):
+            assert get_current_context() is nested_ctx
+
+        # After exiting nested context, original context is restored
+        assert get_current_context() is base_ctx
+
+    # After exiting outer context, there should be no active context
+    with pytest.raises(RuntimeError):
+        get_current_context()
+
+
+def test_use_context_restores_context_on_exception() -> None:
+    """use_context must restore the previous context even when the body raises."""
+    from ghillie.cli.config import ResolvedCliConfig
+
+    outer_ctx = CommandContext(
+        config=ResolvedCliConfig(
+            api_base_url="http://127.0.0.1:8080",
+            api_base_url_source="fallback",
+            auth_token=None,
+            output="table",
+            log_level="info",
+            request_timeout_s=30.0,
+            non_interactive=True,
+            dry_run=False,
+        )
+    )
+    inner_ctx = CommandContext(
+        config=ResolvedCliConfig(
+            api_base_url="http://127.0.0.1:9999",
+            api_base_url_source="flag",
+            auth_token=None,
+            output="json",
+            log_level="debug",
+            request_timeout_s=10.0,
+            non_interactive=False,
+            dry_run=True,
+        )
+    )
+
+    with use_context(outer_ctx):
+        assert get_current_context() is outer_ctx
+
+        def _raise_in_inner_context() -> None:
+            with use_context(inner_ctx):
+                assert get_current_context() is inner_ctx
+                raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            _raise_in_inner_context()
+
+        # The exception from the inner block must not corrupt the outer context
+        assert get_current_context() is outer_ctx
+
+    # No active context after exiting outer block
+    with pytest.raises(RuntimeError):
+        get_current_context()
+
+
+def test_use_context_is_reentrant_and_nestable() -> None:
+    """Multiple nested use_context invocations should unwind in LIFO order."""
+    from ghillie.cli.config import ResolvedCliConfig
+
+    ctx1 = CommandContext(
+        config=ResolvedCliConfig(
+            api_base_url="http://127.0.0.1:8081",
+            api_base_url_source="fallback",
+            auth_token=None,
+            output="table",
+            log_level="info",
+            request_timeout_s=30.0,
+            non_interactive=True,
+            dry_run=False,
+        )
+    )
+    ctx2 = CommandContext(
+        config=ResolvedCliConfig(
+            api_base_url="http://127.0.0.1:8082",
+            api_base_url_source="fallback",
+            auth_token=None,
+            output="table",
+            log_level="info",
+            request_timeout_s=30.0,
+            non_interactive=True,
+            dry_run=False,
+        )
+    )
+    ctx3 = CommandContext(
+        config=ResolvedCliConfig(
+            api_base_url="http://127.0.0.1:8083",
+            api_base_url_source="fallback",
+            auth_token=None,
+            output="table",
+            log_level="info",
+            request_timeout_s=30.0,
+            non_interactive=True,
+            dry_run=False,
+        )
+    )
+
+    with ExitStack() as stack:
+        stack.enter_context(use_context(ctx1))
+        assert get_current_context() is ctx1
+
+        stack.enter_context(use_context(ctx2))
+        assert get_current_context() is ctx2
+
+        stack.enter_context(use_context(ctx3))
+        assert get_current_context() is ctx3
+
+    # After all are closed, there should be no active context
+    with pytest.raises(RuntimeError):
+        get_current_context()

--- a/tests/unit/cli/test_control_plane_client.py
+++ b/tests/unit/cli/test_control_plane_client.py
@@ -1,0 +1,51 @@
+"""Unit tests for the CLI control-plane client wrapper."""
+
+from __future__ import annotations
+
+import httpx
+
+from ghillie.cli.config import ResolvedCliConfig
+from ghillie.cli.control_plane import ControlPlaneClient
+
+
+def test_control_plane_client_uses_base_url_timeout_and_auth_header() -> None:
+    """The HTTP client wrapper should reflect the resolved CLI configuration."""
+    client = ControlPlaneClient(
+        ResolvedCliConfig(
+            api_base_url="http://127.0.0.1:9999",
+            api_base_url_source="flag",
+            auth_token="secret-token",  # noqa: S106
+            output="table",
+            log_level="info",
+            request_timeout_s=12.5,
+            non_interactive=True,
+            dry_run=False,
+        )
+    )
+
+    try:
+        assert client.http_client.base_url == httpx.URL("http://127.0.0.1:9999")
+        assert client.http_client.timeout == httpx.Timeout(12.5)
+        assert client.http_client.headers["Authorization"] == "Bearer secret-token"
+    finally:
+        client.close()
+
+
+def test_control_plane_client_closes_owned_http_client() -> None:
+    """Closing the wrapper should close the owned `httpx.Client` instance."""
+    client = ControlPlaneClient(
+        ResolvedCliConfig(
+            api_base_url="http://127.0.0.1:9999",
+            api_base_url_source="fallback",
+            auth_token=None,
+            output="table",
+            log_level="info",
+            request_timeout_s=30.0,
+            non_interactive=True,
+            dry_run=False,
+        )
+    )
+
+    client.close()
+
+    assert client.http_client.is_closed is True

--- a/tests/unit/cli/test_control_plane_client.py
+++ b/tests/unit/cli/test_control_plane_client.py
@@ -49,3 +49,107 @@ def test_control_plane_client_closes_owned_http_client() -> None:
     client.close()
 
     assert client.http_client.is_closed is True
+
+
+def test_control_plane_client_does_not_send_auth_header_when_token_is_none() -> None:
+    """If auth_token is None, the client should not send an Authorization header."""
+    captured_headers: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal captured_headers
+        captured_headers = dict(request.headers)
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    external_client = httpx.Client(
+        base_url="http://127.0.0.1:9999", transport=transport
+    )
+
+    config = ResolvedCliConfig(
+        api_base_url="http://127.0.0.1:9999",
+        api_base_url_source="flag",
+        auth_token=None,
+        output="table",
+        log_level="info",
+        request_timeout_s=5.0,
+        non_interactive=True,
+        dry_run=False,
+    )
+
+    with ControlPlaneClient(config, http_client=external_client) as client:
+        # Perform any request so we can inspect the headers used.
+        client.http_client.get("/ping")
+
+    # httpx normalizes header names; use case-insensitive lookup.
+    assert "authorization" not in {k.lower(): v for k, v in captured_headers.items()}
+
+
+def test_control_plane_client_context_manager_closes_on_exit() -> None:
+    """The client should always be closed when leaving a context manager."""
+    config = ResolvedCliConfig(
+        api_base_url="http://127.0.0.1:9999",
+        api_base_url_source="flag",
+        auth_token="secret-token",  # noqa: S106
+        output="table",
+        log_level="info",
+        request_timeout_s=5.0,
+        non_interactive=True,
+        dry_run=False,
+    )
+
+    with ControlPlaneClient(config) as client:
+        underlying = client.http_client
+        assert isinstance(underlying, httpx.Client)
+        assert not underlying.is_closed
+
+    # After the context, the underlying client should be closed.
+    assert underlying.is_closed
+
+
+def test_control_plane_client_context_manager_closes_on_exception() -> None:
+    """The client should close even if an exception is raised."""
+    config = ResolvedCliConfig(
+        api_base_url="http://127.0.0.1:9999",
+        api_base_url_source="flag",
+        auth_token="secret-token",  # noqa: S106
+        output="table",
+        log_level="info",
+        request_timeout_s=5.0,
+        non_interactive=True,
+        dry_run=False,
+    )
+
+    def _raise_in_context(client: ControlPlaneClient) -> None:
+        raise RuntimeError("boom")
+
+    try:
+        with ControlPlaneClient(config) as client:
+            underlying = client.http_client
+            _raise_in_context(client)
+    except RuntimeError:
+        pass
+
+    assert underlying.is_closed
+
+
+def test_control_plane_client_does_not_close_external_client() -> None:
+    """When constructed with an external httpx.Client, close() must not close it."""
+    config = ResolvedCliConfig(
+        api_base_url="http://127.0.0.1:9999",
+        api_base_url_source="flag",
+        auth_token="secret-token",  # noqa: S106
+        output="table",
+        log_level="info",
+        request_timeout_s=5.0,
+        non_interactive=True,
+        dry_run=False,
+    )
+
+    external_client = httpx.Client(base_url="http://127.0.0.1:9999")
+
+    control_plane_client = ControlPlaneClient(config, http_client=external_client)
+    control_plane_client.close()
+
+    # The wrapper should respect ownership and not close non-owned clients.
+    assert not external_client.is_closed
+    external_client.close()

--- a/tests/unit/cli/test_global_options.py
+++ b/tests/unit/cli/test_global_options.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+
+from ghillie.cli.app import main as cli_main
 from ghillie.cli.app import parse_global_options
 from ghillie.cli.config import GlobalOptions, resolve_cli_config
 
@@ -56,3 +59,62 @@ def test_resolved_cli_config_preserves_explicit_root_options() -> None:
     assert config.request_timeout_s == 9.0
     assert config.non_interactive is False
     assert config.dry_run is True
+
+
+def test_parse_global_options_boolean_toggles_and_inline_syntax() -> None:
+    """Boolean toggles and inline value syntax should be parsed correctly."""
+    # non-interactive + explicit no-dry-run, inline output value
+    options, remaining = parse_global_options(
+        [
+            "--non-interactive",
+            "--no-dry-run",
+            "--output=json",
+            "report",
+        ]
+    )
+
+    assert options == GlobalOptions(
+        api_base_url=None,
+        auth_token=None,
+        output="json",
+        log_level=None,
+        request_timeout_s=None,
+        non_interactive=True,
+        dry_run=False,
+    )
+    assert remaining == ["report"]
+
+    # interactive cancels non-interactive, dry-run enabled, inline timeout
+    options, remaining = parse_global_options(
+        [
+            "--interactive",
+            "--dry-run",
+            "--request-timeout-s=3.5",
+            "report",
+            "status",
+        ]
+    )
+
+    assert options == GlobalOptions(
+        api_base_url=None,
+        auth_token=None,
+        output=None,
+        log_level=None,
+        request_timeout_s=3.5,
+        non_interactive=False,
+        dry_run=True,
+    )
+    assert remaining == ["report", "status"]
+
+
+def test_parse_global_options_raises_when_value_option_missing_value() -> None:
+    """Value-bearing options without a value should raise ValueError."""
+    with pytest.raises(ValueError, match="requires a value"):
+        parse_global_options(["--api-base-url"])
+
+
+def test_main_exits_with_code_2_on_invalid_request_timeout() -> None:
+    """Invalid --request-timeout-s should cause main() to exit with code 2."""
+    exit_code = cli_main(["--request-timeout-s", "abc", "report"])
+
+    assert exit_code == 2

--- a/tests/unit/cli/test_global_options.py
+++ b/tests/unit/cli/test_global_options.py
@@ -1,0 +1,58 @@
+"""Unit tests for global option parsing and command context construction."""
+
+from __future__ import annotations
+
+from ghillie.cli.app import parse_global_options
+from ghillie.cli.config import GlobalOptions, resolve_cli_config
+
+
+def test_parse_global_options_consumes_root_options_before_noun() -> None:
+    """Known root options should be consumed before the noun command."""
+    options, remaining = parse_global_options(
+        [
+            "--api-base-url",
+            "http://127.0.0.1:9999",
+            "--output=json",
+            "--request-timeout-s",
+            "12.5",
+            "report",
+            "run",
+            "--help",
+        ]
+    )
+
+    assert options == GlobalOptions(
+        api_base_url="http://127.0.0.1:9999",
+        auth_token=None,
+        output="json",
+        log_level=None,
+        request_timeout_s=12.5,
+        non_interactive=None,
+        dry_run=None,
+    )
+    assert remaining == ["report", "run", "--help"]
+
+
+def test_resolved_cli_config_preserves_explicit_root_options() -> None:
+    """Explicit root options should survive resolution into handler context."""
+    config = resolve_cli_config(
+        GlobalOptions(
+            api_base_url="http://127.0.0.1:9999",
+            auth_token="secret-token",  # noqa: S106
+            output="yaml",
+            log_level="debug",
+            request_timeout_s=9.0,
+            non_interactive=False,
+            dry_run=True,
+        ),
+        env={},
+    )
+
+    assert config.api_base_url == "http://127.0.0.1:9999"
+    assert config.api_base_url_source == "flag"
+    assert config.auth_token == "secret-token"  # noqa: S105
+    assert config.output == "yaml"
+    assert config.log_level == "debug"
+    assert config.request_timeout_s == 9.0
+    assert config.non_interactive is False
+    assert config.dry_run is True

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -1,0 +1,76 @@
+"""Unit tests for CLI output formatting helpers."""
+
+from __future__ import annotations
+
+import json
+import typing as typ
+
+import pytest
+import ruamel.yaml
+
+from ghillie.cli.output import render_output
+
+
+@pytest.fixture
+def sample_rows() -> list[dict[str, object]]:
+    """Sample data for output rendering tests."""
+    return [
+        {"name": "alpha", "value": 1, "enabled": True},
+        {"name": "beta", "value": 2, "enabled": False},
+    ]
+
+
+def test_render_output_json_deterministic_key_order(
+    sample_rows: list[dict[str, object]],
+) -> None:
+    """JSON output should be deterministic with respect to key ordering."""
+    payload = typ.cast("typ.Mapping[str, object]", {"items": sample_rows})
+    output = render_output(
+        payload,
+        output="json",
+    )
+
+    # Structural assertion
+    parsed = json.loads(output)
+    assert parsed == {"items": sample_rows}
+
+    # Deterministic key order assertion
+    expected = json.dumps(
+        {"items": sample_rows},
+        sort_keys=True,
+    )
+    assert output == expected
+
+
+def test_render_output_yaml_structure(
+    sample_rows: list[dict[str, object]],
+) -> None:
+    """YAML output should contain a structurally equivalent representation."""
+    payload = typ.cast("typ.Mapping[str, object]", {"items": sample_rows})
+    output = render_output(
+        payload,
+        output="yaml",
+    )
+
+    yaml = ruamel.yaml.YAML(typ="safe")
+    parsed = yaml.load(output)
+    assert parsed == {"items": sample_rows}
+
+
+def test_render_output_table_structure() -> None:
+    """Table output should contain key-value pairs."""
+    payload = typ.cast("typ.Mapping[str, object]", {"name": "test", "count": 42})
+    output = render_output(
+        payload,
+        output="table",
+    )
+
+    # Basic structural checks
+    lines = [line for line in output.splitlines() if line.strip()]
+    assert len(lines) >= 2
+
+    # Ensure each field is present
+    assert any("name" in line for line in lines)
+    assert any("test" in line for line in lines)
+    assert any("count" in line for line in lines)
+    assert any("42" in line for line in lines)

--- a/tests/unit/cli/test_runtime_adapter_selection.py
+++ b/tests/unit/cli/test_runtime_adapter_selection.py
@@ -1,0 +1,27 @@
+"""Unit tests for local runtime adapter selection."""
+
+from __future__ import annotations
+
+import pytest
+
+from ghillie.cli.runtime_adapters import (
+    CuprumRuntimeAdapter,
+    PythonApiRuntimeAdapter,
+    select_runtime_adapter,
+)
+
+
+def test_select_runtime_adapter_accepts_cuprum() -> None:
+    """The documented `cuprum` backend should resolve successfully."""
+    assert isinstance(select_runtime_adapter("cuprum"), CuprumRuntimeAdapter)
+
+
+def test_select_runtime_adapter_accepts_python_api() -> None:
+    """The documented `python-api` backend should resolve successfully."""
+    assert isinstance(select_runtime_adapter("python-api"), PythonApiRuntimeAdapter)
+
+
+def test_select_runtime_adapter_rejects_unknown_backend() -> None:
+    """Unknown runtime backends should fail fast before any side effects."""
+    with pytest.raises(ValueError, match="Unsupported runtime backend"):
+        select_runtime_adapter("invalid")

--- a/tests/unit/cli/test_runtime_adapter_selection.py
+++ b/tests/unit/cli/test_runtime_adapter_selection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from ghillie.cli.commands.params import RuntimeBackend
 from ghillie.cli.runtime_adapters import (
     CuprumRuntimeAdapter,
     PythonApiRuntimeAdapter,
@@ -13,16 +14,16 @@ from ghillie.cli.runtime_adapters import (
 
 def test_select_runtime_adapter_accepts_cuprum() -> None:
     """The documented `cuprum` backend should resolve successfully."""
-    adapter = select_runtime_adapter("cuprum")
+    adapter = select_runtime_adapter(RuntimeBackend.CUPRUM)
     assert isinstance(adapter, CuprumRuntimeAdapter)
-    assert adapter.name == "cuprum"
+    assert adapter.name == RuntimeBackend.CUPRUM
 
 
 def test_select_runtime_adapter_accepts_python_api() -> None:
     """The documented `python-api` backend should resolve successfully."""
-    adapter = select_runtime_adapter("python-api")
+    adapter = select_runtime_adapter(RuntimeBackend.PYTHON_API)
     assert isinstance(adapter, PythonApiRuntimeAdapter)
-    assert adapter.name == "python-api"
+    assert adapter.name == RuntimeBackend.PYTHON_API
 
 
 def test_select_runtime_adapter_rejects_unknown_backend() -> None:

--- a/tests/unit/cli/test_runtime_adapter_selection.py
+++ b/tests/unit/cli/test_runtime_adapter_selection.py
@@ -13,15 +13,21 @@ from ghillie.cli.runtime_adapters import (
 
 def test_select_runtime_adapter_accepts_cuprum() -> None:
     """The documented `cuprum` backend should resolve successfully."""
-    assert isinstance(select_runtime_adapter("cuprum"), CuprumRuntimeAdapter)
+    adapter = select_runtime_adapter("cuprum")
+    assert isinstance(adapter, CuprumRuntimeAdapter)
+    assert adapter.name == "cuprum"
 
 
 def test_select_runtime_adapter_accepts_python_api() -> None:
     """The documented `python-api` backend should resolve successfully."""
-    assert isinstance(select_runtime_adapter("python-api"), PythonApiRuntimeAdapter)
+    adapter = select_runtime_adapter("python-api")
+    assert isinstance(adapter, PythonApiRuntimeAdapter)
+    assert adapter.name == "python-api"
 
 
 def test_select_runtime_adapter_rejects_unknown_backend() -> None:
     """Unknown runtime backends should fail fast before any side effects."""
+    import typing as typ
+
     with pytest.raises(ValueError, match="Unsupported runtime backend"):
-        select_runtime_adapter("invalid")
+        select_runtime_adapter(typ.cast("typ.Any", "invalid"))

--- a/tests/unit/test_catalogue_api.py
+++ b/tests/unit/test_catalogue_api.py
@@ -56,13 +56,11 @@ def test_example_catalogue_json_matches_schema(tmp_path: Path) -> None:
     pajv_path = shutil.which("pajv")
     if pajv_path is None:
         pytest.skip("pajv must be installed to validate the catalogue schema")
-    else:
-        assert pajv_path is not None
+    assert pajv_path is not None
 
     try:
         subprocess.run(  # noqa: S603 - static pajv invocation
             [pajv_path, "-s", str(schema_path), "-d", str(json_path)],
-            text=True,
             capture_output=True,
             encoding="utf-8",
             check=True,

--- a/tests/unit/test_catalogue_schema.py
+++ b/tests/unit/test_catalogue_schema.py
@@ -202,11 +202,11 @@ def test_schema_validates_simple_catalogue(tmp_path: Path) -> None:
     pajv_path = shutil.which("pajv")
     if pajv_path is None:
         pytest.skip("pajv is not installed; skipping JSON Schema validation")
+    assert pajv_path is not None
 
     try:
         subprocess.run(  # noqa: S603 - static pajv invocation
             [pajv_path, "-s", str(schema_path), "-d", str(data_path)],
-            text=True,
             capture_output=True,
             encoding="utf-8",
             check=True,

--- a/uv.lock
+++ b/uv.lock
@@ -193,6 +193,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "cyclopts" },
     { name = "dramatiq" },
     { name = "falcon" },
     { name = "femtologging" },
@@ -207,7 +208,6 @@ dependencies = [
 dev = [
     { name = "asyncpg" },
     { name = "cmd-mox" },
-    { name = "cyclopts" },
     { name = "plumbum" },
     { name = "py-pglite", extra = ["asyncpg"] },
     { name = "pyright" },
@@ -223,6 +223,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "cyclopts", specifier = ">=2.9,<3" },
     { name = "dramatiq", specifier = ">=1.16.0" },
     { name = "falcon", specifier = ">=4.0.0,<5.0.0" },
     { name = "femtologging", git = "https://github.com/leynos/femtologging?rev=7c139fb7aca18f9277e00b88604b8bf5eb471be0" },
@@ -237,7 +238,6 @@ requires-dist = [
 dev = [
     { name = "asyncpg", specifier = ">=0.20.0,<1.0" },
     { name = "cmd-mox", specifier = ">=0.2,<1" },
-    { name = "cyclopts", specifier = ">=2.9,<3" },
     { name = "plumbum", specifier = ">=1.10,<2" },
     { name = "py-pglite", extras = ["asyncpg"], specifier = ">=0.1.0" },
     { name = "pyright" },


### PR DESCRIPTION
## Summary
- Refactors the packaged operator CLI to centralize root/global option parsing and one-shot per-invocation CommandContext propagation to noun handlers. This clarifies config resolution flow and reduces scattered parsing logic in noun handlers, establishing a stable hexagonal CLI surface with driven adapters.
- Maintains and expands the packaged CLI scaffold under `ghillie/cli` with a thin core and driven adapters. Introduces dedicated modules for config, context, control_plane, runtime_adapters, output, plus command modules for nouns (estate, export, ingest, metrics, report, stack) and shared params.
- Exposes a console entry point `ghillie` via pyproject.toml to run as a package-based CLI, with a MVP noun/verb tree for stack, estate, ingest, export, report, and metrics.
- Adds unit tests for CLI app structure, config resolution, global options, and adapter selection; behavioral test scaffolding via pytest-bdd for operator CLI contract; and documentation updates to reflect the MVP CLI scaffold.
- Updates design/docs to reflect the operator CLI contract, boundary, and MVP scope, aligning with Task 2.5.a milestones.

## Changes
- New packaged CLI scaffold under `ghillie/cli/` with:
  - `__init__.py`, `__main__.py`, `app.py`, `config.py`, `context.py`, `control_plane.py`, `runtime_adapters.py`, `output.py`.
  - Command modules for nouns:
    - `ghillie/cli/commands/estate.py`
    - `ghillie/cli/commands/export.py`
    - `ghillie/cli/commands/ingest.py`
    - `ghillie/cli/commands/metrics.py`
    - `ghillie/cli/commands/report.py`
    - `ghillie/cli/commands/stack.py`
  - `ghillie/cli/commands/params.py` (shared parameter types).
- Entry point exposure:
  - `pyproject.toml`: console entry point `ghillie = ghillie.cli:main` (CLI runtime).
- Core concepts introduced:
  - `GlobalOptions`, `ResolvedCliConfig`, `CommandContext`, `ControlPlaneClient`, `LocalRuntimeAdapter`.
- Tests and behavior:
  - Unit tests for CLI app structure, config resolution, global options, and adapter selection (new files under `tests/unit/cli/`).
  - Behavioural test scaffolding under `tests/features/` with Gherkin scenarios for operator CLI contract.
- Documentation/story updates:
  - Expanded docs to reflect MVP CLI scaffold state and boundary (design and MVP spec alignment).
- Milestones and validation updated to reflect Task 2.5.a scaffold delivery.

## Rationale
- Establishes a stable, hexagonal CLI scaffold driven by a thin core and driven adapters. Global/root options are resolved once per invocation and propagated through a single, typed context before dispatch to noun handlers. The CLI surface is designed to be easily extended with estate, ingest, reporting, export, and metrics backends while preserving a deterministic parsing and output path for now (placeholders where appropriate).

## Milestones (high level)
- Milestone 1 — Lock the contract with failing tests
- Milestone 2 — Build the packaged CLI core
- Milestone 3 — Register the noun and verb tree
- Milestone 4 — Wire the driven adapters cleanly
- Milestone 5 — Update the contract documents

## Validation and evidence
- Operator-visible evidence expected after completion:
  - `uv run ghillie --help` lists the top-level nouns: stack, estate, ingest, export, report, metrics.
  - `uv run ghillie stack up --help` reveals backend and wait options.
  - `uv run ghillie --api-base-url http://127.0.0.1:9999 report run --help` parses correctly.
  - invalid backend value yields a specific validation error.

## Documentation impact
- Docs updated to reflect the Operator CLI scaffold boundary, MVP spec alignment, and usage guidance for the new ghillie CLI surface.

## How to review
- Focus on scope, constraints, and milestones. Confirm alignment with the MVP CLI specification and measurable acceptance criteria.

## Task references
- Task: https://www.devboxer.com/task/d2e1afbc-9624-430f-a0f3-6d012a81bc0d
- Task: https://www.devboxer.com/task/17ee711b-9cfd-40a9-bf38-d9768a57c6a6