### PR TITLE
Adopt Hecate architecture checks (1.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check formatting
         run: make check-fmt
 
-      - name: Run ruff
+      - name: Run architecture and lint checks
         run: make lint
 
       - name: Run typechecker

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TOOLS = $(MDFORMAT_ALL) ruff ty $(MDLINT) uv
 VENV_TOOLS = pytest
 UV_ENV = UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
 
-.PHONY: help all clean build build-release lint fmt check-fmt \
+.PHONY: help all clean build build-release check-architecture lint fmt check-fmt \
         markdownlint nixie test typecheck helm-lint helm-test \
         docker-build docker-run $(TOOLS) $(VENV_TOOLS)
 
@@ -63,7 +63,10 @@ check-fmt: ruff ## Verify formatting
 	ruff format --check
 	# mdformat-all doesn't currently do checking
 
-lint: ruff ## Run linters
+check-architecture: build ## Run hexagonal architecture import checks
+	$(UV_ENV) uv run scripts/check_architecture.py
+
+lint: check-architecture ruff ## Run linters
 	ruff check
 
 typecheck: build ty ## Run typechecking

--- a/docs/adr-003-adopt-hecate-for-architecture-checks.md
+++ b/docs/adr-003-adopt-hecate-for-architecture-checks.md
@@ -1,0 +1,126 @@
+# ADR-003: Adoption of Hecate for architecture checks
+
+## Status
+
+Accepted (implemented on 2026-06-01)
+
+## Context
+
+Ghillie uses a hexagonal ports-and-adapters architecture over a Medallion data
+pipeline. The design documents describe domain, application, inbound adapter,
+outbound adapter, and composition-root responsibilities, but the repository did
+not have a dedicated import-direction gate. Behavioural tests covered runtime
+selection, factories, report sinks, storage effects, and CLI contracts, but
+they did not continuously check that Python imports preserve the intended
+architecture.
+
+Architecture drift is likely when new modules are added because Python import
+edges are easy to introduce during feature work. A static checker must
+therefore be:
+
+- runnable locally through Make,
+- deterministic enough for Continuous Integration (CI),
+- configured from repository source control,
+- explicit about documented exceptions, and
+- scoped to import direction rather than runtime behaviour.
+
+Hecate is a Python import architecture checker for hexagonal projects. It reads
+`[tool.hecate]` from `pyproject.toml`, classifies modules into ordered groups,
+expands package re-exports, and reports forbidden group-to-group imports.
+
+## Decision
+
+Adopt Hecate as Ghillie's canonical static architecture fitness function using
+commit `46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12`.
+
+The project will:
+
+1. Add Hecate to the development dependency group using the pinned Git commit.
+2. Store the architecture policy in `[tool.hecate]` in `pyproject.toml`.
+3. Provide `make check-architecture` as the local architecture gate.
+4. Run `check-architecture` before Ruff as part of `make lint`.
+5. Keep behaviour tests for runtime behaviour and use Hecate only for static
+   import-boundary checks.
+
+### Compatibility note
+
+The pinned Hecate CLI cannot run directly with Ghillie's previous
+`cyclopts>=2.9,<3` dependency because it uses callable `cyclopts.Parameter`.
+Ghillie now permits `cyclopts>=3,<4`. Cyclopts `3.24.0` still lacks Hecate's
+`result_action` keyword, so `make check-architecture` runs Hecate through
+`scripts/check_architecture.py`, a narrow compatibility wrapper that removes
+only that unsupported keyword before importing Hecate's CLI.
+
+The wrapper is temporary. It should be removed when the pinned Hecate commit is
+advanced to a version whose CLI dependency declaration and Cyclopts usage are
+aligned.
+
+## Consequences
+
+### Positive
+
+- Import-direction drift is caught by a deterministic local and CI gate.
+- The Hecate policy lives beside other Python tooling configuration in
+  `pyproject.toml`.
+- Behaviour tests can stay focused on observable behaviour instead of acting as
+  architecture sentinels.
+- New module-boundary decisions require explicit policy updates or documented
+  exceptions.
+
+### Negative
+
+- Hecate is pinned from Git rather than a package index release.
+- The initial adoption needs a small compatibility wrapper for the pinned
+  Hecate CLI.
+- Contributors must maintain ordered Hecate groups when adding new package
+  boundaries.
+
+### Neutral
+
+- No public Ghillie Python API, CLI command, HTTP route, storage schema, or
+  runtime configuration changes.
+- Existing behaviour tests remain in place.
+
+## Alternatives considered
+
+### Keep relying on tests and review
+
+This requires reviewers to spot import-boundary drift manually and makes
+architecture enforcement inconsistent. It was rejected because the repository
+already has enough modules and adapters for accidental coupling to be plausible.
+
+### Write a repository-local checker
+
+A local checker would avoid the Hecate CLI compatibility wrapper, but it would
+duplicate import parsing, package re-export handling, policy validation, and
+diagnostic rendering. It was rejected in favour of a shared checker with its
+own test suite.
+
+### Adopt Import Linter
+
+Import Linter is mature and widely used, but Hecate's policy model directly
+matches the composition-root, domain-port, application, inbound-adapter, and
+outbound-adapter grouping used by related df12 projects. Hecate was selected
+for consistency with that ecosystem.
+
+## Rollback
+
+To roll back this decision:
+
+1. Remove the Hecate development dependency and lockfile entry.
+2. Remove `[tool.hecate]` from `pyproject.toml`.
+3. Remove `scripts/check_architecture.py`.
+4. Remove `check-architecture` from `Makefile` and `make lint`.
+5. Remove the CI lint-step wording that mentions architecture checks.
+6. Supersede this ADR with a replacement decision rather than deleting the
+   historical record.
+
+## References
+
+- Hecate users' guide:
+  <https://raw.githubusercontent.com/leynos/hecate/46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12/docs/users-guide.md>
+- Hecate configuration guide:
+  <https://raw.githubusercontent.com/leynos/hecate/46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12/docs/configuration.md>
+- Hecate Episodic migration notes:
+  <https://raw.githubusercontent.com/leynos/hecate/46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12/docs/migration-episodic.md>
+- Implementation plan: `docs/execplans/adopt-hecate.md`

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -70,8 +70,8 @@ or moving modules:
   group classification;
 - keep composition-root prefixes narrow and explicit;
 - prefer refactoring a dependency edge over adding `ignore_imports`;
-- if an ignore is unavoidable, include a precise reason that explains why the
-  edge is intentional; and
+- if an ignore rule is unavoidable, include a precise reason that explains why
+  the edge is intentional; and
 - run `make check-architecture` before opening a pull request.
 
 The current policy groups modules as composition roots, domain ports,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -33,21 +33,50 @@ This runs formatting checks, linting, type checking, and tests.
 
 The project enforces these quality gates before commits:
 
-| Target           | Description                        |
-| ---------------- | ---------------------------------- |
-| `make fmt`       | Format Python and Markdown sources |
-| `make lint`      | Run ruff linter                    |
-| `make check-fmt` | Verify formatting without changes  |
-| `make typecheck` | Run the type checker               |
-| `make test`      | Run pytest with parallel execution |
-| `make helm-lint` | Lint the Ghillie Helm chart        |
-| `make helm-test` | Run Helm chart tests               |
+| Target                    | Description                                     |
+| ------------------------- | ----------------------------------------------- |
+| `make fmt`                | Format Python and Markdown sources              |
+| `make check-architecture` | Run Hecate import-direction architecture checks |
+| `make lint`               | Run Hecate and Ruff lint checks                 |
+| `make check-fmt`          | Verify formatting without changes               |
+| `make typecheck`          | Run the type checker                            |
+| `make test`               | Run pytest with parallel execution              |
+| `make helm-lint`          | Lint the Ghillie Helm chart                     |
+| `make helm-test`          | Run Helm chart tests                            |
 
 Run all gates before committing:
 
 ```bash
 make check-fmt && make lint && make typecheck && make test && make helm-lint
 ```
+
+## Architecture checks
+
+Ghillie uses Hecate as the static architecture fitness function for Python
+import direction. Run it directly with:
+
+```bash
+make check-architecture
+```
+
+The same check runs before Ruff as part of `make lint`, so CI and local linting
+share the same architecture gate.
+
+The Hecate policy is stored in `[tool.hecate]` in `pyproject.toml`. When adding
+or moving modules:
+
+- update the policy if the module introduces a new package boundary;
+- put specific prefixes before broad prefixes because Hecate uses first-match
+  group classification;
+- keep composition-root prefixes narrow and explicit;
+- prefer refactoring a dependency edge over adding `ignore_imports`;
+- if an ignore is unavoidable, include a precise reason that explains why the
+  edge is intentional; and
+- run `make check-architecture` before opening a pull request.
+
+The current policy groups modules as composition roots, domain ports,
+application modules, inbound adapters, and outbound adapters. The adoption
+rationale is recorded in `docs/adr-003-adopt-hecate-for-architecture-checks.md`.
 
 ## Code style and type handling
 

--- a/docs/execplans/adopt-hecate.md
+++ b/docs/execplans/adopt-hecate.md
@@ -1,0 +1,560 @@
+# Adopt Hecate for hexagonal architecture checks
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+This plan must be explicitly approved before implementation starts. The current
+branch carries only the plan and review material.
+
+## Purpose / big picture
+
+Ghillie currently documents a hexagonal ports-and-adapters architecture and
+maintains important seams with protocol-focused unit and behavioural tests, but
+it does not have a dedicated automated import-direction gate. After this plan
+is approved and implemented, Ghillie will use
+[Hecate](https://github.com/leynos/hecate) at commit
+`46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12` as the canonical architecture
+fitness function for Python import boundaries.
+
+A maintainer will be able to run `make check-architecture` from the repository
+root and see Hecate check `ghillie` imports against a TOML policy. Continuous
+Integration (CI) will run the same gate before tests. Behavioural tests will
+remain responsible for runtime behaviour, while Hecate will own static
+dependency-direction drift detection.
+
+This work uses the `leta`, `hexagonal-architecture`, and `execplans` skills.
+Use `leta` for code navigation, the `hexagonal-architecture` skill for boundary
+decisions, and the `execplans` skill for keeping this plan current. If Rust
+code is touched unexpectedly, route through the `rust-router` skill before
+making changes.
+
+## Constraints
+
+- Do not implement this plan until the user explicitly approves it.
+- Pin Hecate to commit `46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12`; do not use a
+  floating branch or version range for the initial adoption.
+- Keep project behaviour unchanged. This migration adds a development and CI
+  architecture gate; it must not alter the public `ghillie` Python API, the
+  `ghillie` command-line interface (CLI), HTTP API responses, storage schema,
+  or runtime configuration.
+- Keep behaviour-heavy tests for reporting, CLI user experience, model
+  selection, ingestion, local Kubernetes tooling, and storage semantics.
+  Replace only tests or assertions that exist solely to enforce import
+  boundaries or protocol placement.
+- Prefer Makefile targets over direct commands. Use `tee` for long-running
+  gates, writing logs under `/tmp`.
+- Run `make check-fmt`, `make lint`, `make typecheck`, and `make test`
+  sequentially before every CodeRabbit review request and before committing
+  implementation changes.
+- Run documentation gates after Markdown changes: `make markdownlint` and
+  `make nixie`.
+- Do not mark any roadmap task done until the Hecate migration itself is
+  implemented, validated, reviewed, and committed. This planning branch must
+  not claim feature completion.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires changes to more than 12 files or more than
+  500 net lines outside generated lockfile changes, stop, and request approval.
+- Interface: if any public API signature, CLI option, HTTP route, database
+  table, or environment variable must change, stop and request approval.
+- Dependencies: Hecate is the only new dependency authorized by this plan. If
+  another dependency appears necessary, stop and request approval.
+- Policy exceptions: if more than five `[[tool.hecate.ignore_imports]]` entries
+  are required for the initial pass, stop and present the violations for human
+  review.
+- Architecture ambiguity: if a module can reasonably belong to two groups and
+  the choice changes allowed imports, record the alternatives and ask for
+  direction.
+- Validation: if any gate still fails after two focused fix attempts, stop,
+  document the failure, and ask for direction.
+- CodeRabbit: if CodeRabbit raises a concern after a milestone, clear it or
+  document why it is not applicable before moving to the next milestone.
+
+## Risks
+
+- Risk: Hecate's first-match group ordering may classify a module into a broad
+  group before a more specific one. Severity: high. Likelihood: medium.
+  Mitigation: order specific composition-root and adapter prefixes before
+  broader package prefixes, and add a policy test that checks representative
+  modules land in the intended groups.
+
+- Risk: Ghillie's current module layout mixes Medallion data layers, application
+  services, and adapters, so an overly strict first policy could produce noisy
+  violations. Severity: high. Likelihood: medium. Mitigation: start with a
+  documented policy that matches the current intended boundaries, add only
+  justified ignores, and escalate if the policy would require structural
+  refactoring beyond this adoption.
+
+- Risk: replacing broad protocol or wiring tests with Hecate could accidentally
+  remove behaviour coverage. Severity: medium. Likelihood: medium. Mitigation:
+  remove or rewrite only assertions that duplicate import-boundary checks. Keep
+  tests that exercise user-visible behaviour, runtime adapter behaviour, retry
+  logic, metrics, and CLI output.
+
+- Risk: pinning Hecate from Git may make CI sensitive to network or resolver
+  behaviour. Severity: medium. Likelihood: low. Mitigation: add Hecate to the
+  existing `uv` dependency workflow, commit the lockfile update if one is
+  produced, and validate in a clean `make build`.
+
+- Risk: developers may not know how to update the policy when adding modules.
+  Severity: medium. Likelihood: medium. Mitigation: update
+  `docs/developers-guide.md` with the new gate, group ordering convention, and
+  ignore-entry rules.
+
+## Progress
+
+- [x] (2026-05-24T19:03:55Z) Loaded the requested `leta`,
+  `hexagonal-architecture`, and `execplans` skills.
+- [x] (2026-05-24T19:03:55Z) Created the Leta workspace for this worktree with
+  `leta workspace add`.
+- [x] (2026-05-24T19:03:55Z) Renamed the branch to `adopt-hecate`, pushed it,
+  and set it to track `origin/adopt-hecate`.
+- [x] (2026-05-24T19:03:55Z) Used a Wyvern agent team for read-only planning
+  reconnaissance across repository documents, existing architecture seams, and
+  Hecate source documentation.
+- [x] (2026-05-24T19:03:55Z) Confirmed there is no existing `hecate` target,
+  dedicated check-architecture target, or repo-local check-architecture script.
+- [x] (2026-05-24T19:03:55Z) Drafted this pre-implementation ExecPlan.
+- [ ] Obtain approval for this ExecPlan before implementation.
+- [ ] Implement Hecate adoption after approval.
+- [ ] Validate implementation with local gates, CodeRabbit, and review.
+- [ ] Mark the relevant roadmap entry done only after implementation is
+  complete.
+
+## Surprises & discoveries
+
+- Observation: The repository does not currently contain a dedicated
+  automated hexagonal architecture check. Evidence: Searches across
+  `Makefile`, `.github`, `scripts`, `tests`, `ghillie`, and `docs` found
+  protocol and behaviour tests, but no Hecate, check-architecture target,
+  or import-boundary script. Impact: The migration is best treated as adding
+  a new canonical static gate and retiring only any future-discovered
+  structural assertions, not as a one-for-one script replacement.
+
+- Observation: One reconnaissance pass initially found report correctness
+  checks rather than architecture-boundary checks. Evidence: The referenced
+  files were `docs/ghillie-design.md` section 9.6.1 and `docs/users-guide.md`
+  report validation text, which cover LLM report validation, not Python import
+  boundaries. Impact: Do not update report correctness behaviour unless
+  implementation work independently touches it.
+
+## Decision log
+
+- Decision: Treat this branch as a pre-implementation planning branch.
+  Rationale: The `execplans` skill requires explicit approval before execution,
+  and the user specifically reminded that the plan must be approved before it
+  is implemented. Date/Author: 2026-05-24T19:03:55Z / AI-proposed.
+
+- Decision: Add Hecate as a development and CI gate rather than a public
+  Ghillie CLI feature. Rationale: Hecate checks repository architecture during
+  development. Exposing it through `ghillie` would create a new public
+  interface that is not needed for the requested migration. Date/Author:
+  2026-05-24T19:03:55Z / AI-proposed.
+
+- Decision: Record the adoption in an Architecture Decision Record (ADR) during
+  implementation. Rationale: Replacing informal architecture enforcement with a
+  pinned external checker is a substantive engineering practice decision, not
+  only a local Makefile change. Date/Author: 2026-05-24T19:03:55Z / AI-proposed.
+
+- Decision: Keep behavioural tests unless they solely assert structural import
+  boundaries. Rationale: Hecate can prove static dependency direction, but it
+  cannot prove CLI behaviour, adapter runtime selection, report formatting,
+  retry semantics, or storage effects. Date/Author: 2026-05-24T19:03:55Z /
+  AI-proposed.
+
+## Outcomes & retrospective
+
+The plan is currently drafted and awaiting approval. No implementation outcome
+exists yet.
+
+## Context and orientation
+
+Ghillie is a Python 3.14 project under `ghillie/`. The architecture combines a
+Medallion data model with hexagonal ports and adapters:
+
+- Bronze modules such as `ghillie/bronze/services.py` and
+  `ghillie/bronze/storage.py` handle raw event persistence.
+- Silver modules such as `ghillie/silver/services.py`,
+  `ghillie/silver/storage.py`, and `ghillie/silver/transformers.py` materialize
+  structured entities.
+- Gold modules such as `ghillie/gold/storage.py` persist report metadata.
+- Application services live across modules such as `ghillie/reporting`,
+  `ghillie/evidence`, `ghillie/registry`, and `ghillie/github/ingestion.py`.
+- Inbound adapters include `ghillie/api`, `ghillie/cli`, and
+  `ghillie/catalogue/cli.py`.
+- Outbound adapters include concrete filesystem, OpenAI, GitHub GraphQL, and
+  SQLAlchemy integrations.
+- Ports are currently represented by protocols such as
+  `ghillie/reporting/sink.py::ReportSink`,
+  `ghillie/status/protocol.py::StatusModel`,
+  `ghillie/cli/runtime_adapters.py::LocalRuntimeAdapter`, and
+  `ghillie/github/client.py::GitHubActivityClient`.
+
+The design source of truth for this work is:
+
+- `docs/ghillie-design.md`, especially section 8.4 for HTTP API
+  ports-and-adapters structure and section 9 for evidence/reporting services.
+- `docs/ghillie-proposal.md`, for the original governance and reporting
+  direction.
+- `docs/ghillie-bronze-silver-architecture-design.md`, for Bronze and Silver
+  component boundaries.
+- `docs/developers-guide.md`, for contributor-facing quality gates and
+  internally facing conventions.
+- `docs/documentation-style-guide.md`, for Markdown, ADR, and roadmap
+  conventions.
+- `docs/roadmap.md`, for the eventual completion marker after implementation.
+
+The Hecate source documents for the pinned adoption are:
+
+- Hecate users' guide:
+  <https://raw.githubusercontent.com/leynos/hecate/46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12/docs/users-guide.md>
+- Hecate migration notes:
+  <https://raw.githubusercontent.com/leynos/hecate/46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12/docs/migration-episodic.md>
+- Hecate configuration guide:
+  <https://raw.githubusercontent.com/leynos/hecate/46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12/docs/configuration.md>
+
+Hecate reads `[tool.hecate]` from `pyproject.toml` by default. It supports
+ordered `[[tool.hecate.groups]]` tables, `allowed` group lists,
+`[[tool.hecate.ignore_imports]]` entries with reasons, `--format json`,
+`--show-ignored`, and `--fail-on-unmatched-ignore`. Exit code `0` means pass,
+`1` means architecture violations, and `2` means configuration or package-root
+validation failed.
+
+## Plan of work
+
+### Stage A: baseline and policy inventory
+
+Confirm the current branch, status, and clean starting point. Use `leta files`
+and `leta grep` for code navigation. Use text search only for documentation,
+configuration, and literal strings.
+
+Inventory imports and architecture seams without changing code. Identify which
+modules should belong to each Hecate group. Start from these candidate groups,
+then adjust only with documented evidence:
+
+- `composition_root`: narrow wiring modules that are allowed to import across
+  groups, such as `ghillie.runtime`, `ghillie.api.app`, `ghillie.api.factory`,
+  `ghillie.cli.app`, and `ghillie.status.factory`.
+- `domain_ports`: protocol and model modules that must stay inward-facing,
+  such as `ghillie.status.protocol`, `ghillie.reporting.sink`,
+  `ghillie.evidence.models`, `ghillie.catalogue.models`, and common value
+  helpers under `ghillie.common`.
+- `application`: orchestration and transformation modules, such as
+  `ghillie.reporting.service`, `ghillie.reporting.metrics_service`,
+  `ghillie.evidence.service`, `ghillie.evidence.project_service`,
+  `ghillie.registry.service`, `ghillie.registry.sync`,
+  `ghillie.bronze.services`, and `ghillie.silver.services`.
+- `inbound_adapter`: external entrypoints such as `ghillie.api`,
+  `ghillie.cli`, and `ghillie.catalogue.cli`.
+- `outbound_adapter`: concrete infrastructure integrations such as
+  `ghillie.github.client`, `ghillie.status.openai_client`,
+  `ghillie.reporting.filesystem_sink`, and SQLAlchemy storage modules.
+
+The exact policy may differ after inventory. If a module is both a port and an
+adapter today, record that ambiguity in the decision log before choosing a
+group.
+
+Stage A validation is documentary: update this plan with any discoveries and
+do not proceed if the group map is ambiguous enough to change public
+behaviour or require broad refactoring.
+
+### Stage B: add the Hecate gate
+
+Add Hecate to `pyproject.toml` in the `dev` dependency group as a Git-pinned
+dependency:
+
+```toml
+"hecate @ git+https://github.com/leynos/hecate@46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12",
+```
+
+Run `make build` so `uv` updates the environment and lockfile if required.
+
+Add `[tool.hecate]` to `pyproject.toml` with `root_packages = ["ghillie"]` and
+ordered `[[tool.hecate.groups]]` entries. Put specific prefixes before broad
+ones. Use `[[tool.hecate.ignore_imports]]` only for intentional edges with
+non-empty reasons.
+
+Add a Makefile target named `check-architecture`:
+
+```make
+check-architecture: build ## Run hexagonal architecture import checks
+	$(UV_ENV) uv run hecate check --show-ignored --fail-on-unmatched-ignore
+```
+
+Add `check-architecture` to `.PHONY` and make it a dependency of the existing
+`lint` target so `make lint` runs Hecate before `ruff check`. Do not add a
+separate `check-architecture` entry to the `all` dependency chain, because
+`all` already runs `lint`. Update `.github/workflows/ci.yml` only if the lint
+step name needs to stop saying "Run ruff" once `make lint` covers both Hecate
+and Ruff.
+
+The resulting lint target should keep Ruff as the Python linter while making
+Hecate the first lint-stage dependency:
+
+```make
+lint: check-architecture ruff ## Run linters
+	ruff check
+```
+
+Stage B validation:
+
+```bash
+make build 2>&1 | tee /tmp/build-ghillie-adopt-hecate.out
+make check-architecture 2>&1 | tee /tmp/check-architecture-ghillie-adopt-hecate.out
+make lint 2>&1 | tee /tmp/lint-ghillie-adopt-hecate.out
+```
+
+Expected result: all commands exit `0`. If Hecate exits `1`, inspect the
+violations and either correct the policy or escalate if the code requires
+refactoring beyond this plan. If Hecate exits `2`, fix configuration before
+continuing.
+
+### Stage C: replace structural checks without losing behaviour coverage
+
+Search tests for assertions that only protect architecture structure. Candidate
+test files to review include:
+
+- `tests/unit/cli/test_runtime_adapter_selection.py`
+- `tests/unit/status/test_factory.py`
+- `tests/unit/test_status_protocol.py`
+- `tests/unit/test_reporting_sink_integration.py`
+- `tests/unit/test_filesystem_sink.py`
+- `tests/unit/cli/test_config_resolution.py`
+- `tests/unit/cli/test_app.py`
+- `tests/unit/cli/test_global_options.py`
+- `tests/unit/cli/test_control_plane_client.py`
+- `tests/unit/cli/test_context.py`
+
+Keep tests that exercise runtime selection, CLI output, error handling, report
+writing, metrics, storage, or service behaviour. Remove or rewrite only
+assertions that duplicate Hecate's import-boundary responsibility. If no such
+assertions exist, record that the implementation adds a new gate and does not
+delete tests.
+
+Add a small policy test if useful, for example
+`tests/unit/test_architecture_policy.py`, that runs Hecate in JSON mode against
+the repository policy or validates representative group classification if
+Hecate exposes a stable API. Do not duplicate Hecate's own semantic test suite
+inside Ghillie.
+
+Stage C validation:
+
+```bash
+make check-architecture 2>&1 | tee /tmp/check-architecture-ghillie-adopt-hecate.out
+make test 2>&1 | tee /tmp/test-ghillie-adopt-hecate.out
+```
+
+Expected result: both commands exit `0`, and any removed tests are replaced by
+the Make/CI architecture gate or narrower behaviour tests.
+
+### Stage D: documentation and decision records
+
+Create `docs/adr-003-adopt-hecate-for-architecture-checks.md` using the style
+of the existing ADR files. Record the decision to use Hecate, the pinned
+commit, the alternatives considered, the consequences, and the rollback path.
+
+Update `docs/ghillie-design.md` near section 8.4 to describe Hecate as the
+static architecture fitness function for ports-and-adapters import direction.
+Reference the ADR for the full rationale.
+
+Update `docs/ghillie-bronze-silver-architecture-design.md` only if the final
+policy documents Bronze and Silver module group conventions that are not
+already stated there.
+
+Update `docs/developers-guide.md` to add `make check-architecture` to the
+quality-gate table and to document contributor conventions:
+
+- update `[tool.hecate]` when adding a new package boundary;
+- place specific prefixes before broad prefixes;
+- prefer refactoring over `ignore_imports`;
+- every ignore must include a precise reason;
+- run `make check-architecture` before opening a pull request.
+
+Update `docs/users-guide.md` only if implementation changes public Ghillie
+runtime behaviour, CLI behaviour, or library API. A development-only Makefile
+gate does not need user-facing documentation.
+
+Update `docs/roadmap.md` after implementation, validation, and review. If no
+existing roadmap task precisely covers this adoption, add or update the narrow
+relevant entry according to `docs/documentation-style-guide.md`, then mark it
+done in the same implementation branch once the feature is complete.
+
+Stage D validation:
+
+```bash
+make fmt 2>&1 | tee /tmp/fmt-ghillie-adopt-hecate.out
+make markdownlint 2>&1 | tee /tmp/markdownlint-ghillie-adopt-hecate.out
+make nixie 2>&1 | tee /tmp/nixie-ghillie-adopt-hecate.out
+```
+
+Expected result: Markdown formatting, linting, and Mermaid validation pass.
+
+### Stage E: full gates, CodeRabbit, commits, and PR update
+
+Run the full required local gate sequence sequentially:
+
+```bash
+make check-fmt 2>&1 | tee /tmp/check-fmt-ghillie-adopt-hecate.out
+make lint 2>&1 | tee /tmp/lint-ghillie-adopt-hecate.out
+make typecheck 2>&1 | tee /tmp/typecheck-ghillie-adopt-hecate.out
+make test 2>&1 | tee /tmp/test-ghillie-adopt-hecate.out
+```
+
+Request CodeRabbit review only after these deterministic gates pass:
+
+```bash
+coderabbit review --agent
+```
+
+Clear all actionable CodeRabbit concerns before moving on. Commit each
+validated milestone with a file-based commit message. Push the branch and
+update the draft pull request summary to mention
+`docs/execplans/adopt-hecate.md`.
+
+## Concrete steps
+
+1. Confirm branch and status:
+
+   ```bash
+   git branch --show-current
+   git status --short --branch
+   ```
+
+   Expected output includes:
+
+   ```plaintext
+   adopt-hecate
+   ## adopt-hecate...origin/adopt-hecate
+   ```
+
+2. After approval, inspect source structure with Leta:
+
+   ```bash
+   leta files ghillie
+   leta grep ".*" "ghillie/(api|cli|reporting|status|github|bronze|silver|gold)" -k function,method,class
+   ```
+
+3. Add the Hecate dependency and `[tool.hecate]` policy in `pyproject.toml`.
+
+4. Add `check-architecture` to `Makefile` and wire it through `make lint`.
+
+5. Run the Stage B validation commands and record results in this plan.
+
+6. Review candidate tests and remove only structural duplication.
+
+7. Add or update docs and ADRs from Stage D.
+
+8. Run the full Stage E gates and CodeRabbit review.
+
+9. Mark the relevant roadmap entry done after implementation is complete.
+
+10. Commit, push, and update the draft pull request.
+
+## Validation and acceptance
+
+The implementation is accepted when all the following are true:
+
+- `make check-architecture` exits `0` and checks `ghillie` with Hecate pinned to
+  `46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12`.
+- CI runs `make lint` before tests, and `make lint` runs
+  `check-architecture` before Ruff.
+- `make check-fmt`, `make lint`, `make typecheck`, and `make test` all exit
+  `0`.
+- `make markdownlint` and `make nixie` exit `0` after documentation changes.
+- CodeRabbit review has no unresolved actionable concerns.
+- The ADR records the Hecate adoption decision.
+- `docs/developers-guide.md` documents the new gate and maintenance practice.
+- `docs/ghillie-design.md` references Hecate as the architecture fitness
+  function.
+- `docs/users-guide.md` is updated if and only if public user-visible behaviour
+  changes.
+- The relevant roadmap entry is marked done only after the feature is
+  implemented and validated.
+
+## Idempotence and recovery
+
+The Makefile and Hecate checks are safe to rerun. If `make build` changes the
+lockfile, keep the lockfile with the dependency change and rerun all gates.
+
+If the Hecate policy causes many violations, do not hide them with broad
+ignores. Revert the policy edits for the current milestone, record the
+violations in this plan, and ask whether to broaden the implementation into a
+module refactor.
+
+If CodeRabbit reports a concern, fix it in a focused commit and rerun the
+deterministic gates before requesting another review.
+
+Rollback for the implementation is straightforward: remove the Hecate
+dependency, `[tool.hecate]` table, `check-architecture` Makefile target, lint
+dependency, and any tests or docs that depend on the new gate. Do not remove
+the ADR unless the decision itself is reversed; supersede it with a new ADR if
+needed.
+
+## Artifacts and notes
+
+Initial planning evidence:
+
+```plaintext
+git branch --show-current
+adopt-hecate
+
+leta workspace add /home/leynos/.lody/repos/github---leynos---ghillie/worktrees/9a262b6c-18f3-4aba-9e62-285e6acc9544
+Added workspace: /home/leynos/.lody/repos/github---leynos---ghillie/worktrees/9a262b6c-18f3-4aba-9e62-285e6acc9544
+```
+
+Wyvern reconnaissance found no existing Hecate or check-architecture target in
+`Makefile`, `.github/workflows/ci.yml`, or `scripts/`. It identified current
+architecture seams in `ghillie/cli/runtime_adapters.py`,
+`ghillie/status/protocol.py`, `ghillie/reporting/sink.py`,
+`ghillie/status/factory.py`, `ghillie/api/factory.py`,
+`ghillie/reporting/service.py`, and `ghillie/github/client.py`.
+
+## Interfaces and dependencies
+
+The implementation must introduce these interfaces:
+
+```toml
+[tool.hecate]
+root_packages = ["ghillie"]
+
+[[tool.hecate.groups]]
+name = "composition_root"
+prefixes = ["ghillie.runtime"]
+allowed = [
+    "application",
+    "composition_root",
+    "domain_ports",
+    "inbound_adapter",
+    "outbound_adapter",
+]
+```
+
+The final policy will include additional groups and prefixes discovered during
+Stage A. The exact allowed sets must preserve the hexagonal dependency rule:
+domain and port modules do not import adapters; application modules depend on
+ports and other application modules; adapters depend inward on application and
+ports; composition roots may wire across groups.
+
+The Makefile interface must be:
+
+```make
+check-architecture: build ## Run hexagonal architecture import checks
+	$(UV_ENV) uv run hecate check --show-ignored --fail-on-unmatched-ignore
+```
+
+The dependency must be pinned exactly:
+
+```toml
+"hecate @ git+https://github.com/leynos/hecate@46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12",
+```
+
+Revision note:
+
+Initial draft created on 2026-05-24. This revision establishes a
+pre-implementation approval gate, records source-document findings, and defines
+the staged migration from informal architecture seams to a pinned Hecate gate.

--- a/docs/execplans/adopt-hecate.md
+++ b/docs/execplans/adopt-hecate.md
@@ -1,9 +1,8 @@
 # Adopt Hecate for hexagonal architecture checks
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: IMPLEMENTING
 
@@ -26,8 +25,8 @@ Integration (CI) will run the same gate before tests. Behavioural tests will
 remain responsible for runtime behaviour, while Hecate will own static
 dependency-direction drift detection.
 
-This work uses the `leta`, `hexagonal-architecture`, and `execplans` skills.
-Use `leta` for code navigation, the `hexagonal-architecture` skill for boundary
+This work uses the `leta`, `hexagonal-architecture`, and `execplans` skills. Use
+`leta` for code navigation, the `hexagonal-architecture` skill for boundary
 decisions, and the `execplans` skill for keeping this plan current. If Rust
 code is touched unexpectedly, route through the `rust-router` skill before
 making changes.
@@ -151,8 +150,35 @@ making changes.
   `make build`, `make check-architecture`, and `make lint` all exit `0`.
 - [x] (2026-06-01T21:44:55Z) Milestone gate passed before commit:
   `make check-fmt`, `make lint`, `make typecheck`, `make test`,
-  `make markdownlint`, `make nixie`, and `mbake validate Makefile` all
-  exit `0`; tests report 809 passed, 11 skipped, and 24 warnings.
+  `make markdownlint`, `make nixie`, and `mbake validate Makefile` all exit
+  `0`; tests report 809 passed, 11 skipped, and 24 warnings.
+- [x] (2026-06-01T21:44:55Z) Committed Stage B as
+      `d9a5078 Add Hecate architecture gate`.
+- [x] (2026-06-01T21:44:55Z) Ran `coderabbit review --agent` after Stage B
+  gates; CodeRabbit reported 0 findings.
+- [x] (2026-06-01T21:44:55Z) Reviewed candidate structural tests named in
+  Stage C. They cover runtime selection, status model factory behaviour,
+  runtime-checkable protocols, report sink effects, CLI command shape, config
+  precedence, context handling, and control-plane client behaviour. No tests
+  were removed because none solely duplicated Hecate import-boundary checks.
+- [x] (2026-06-01T21:44:55Z) Added
+  `docs/adr-003-adopt-hecate-for-architecture-checks.md` for the Hecate
+  adoption decision.
+- [x] (2026-06-01T21:44:55Z) Updated `docs/ghillie-design.md`,
+  `docs/ghillie-bronze-silver-architecture-design.md`,
+  `docs/developers-guide.md`, and `docs/roadmap.md` for the Hecate gate, policy
+  maintenance rules, and completed roadmap task.
+- [x] (2026-06-01T21:44:55Z) Confirmed `docs/users-guide.md` does not need a
+  change because this implementation adds a development/CI gate and does not
+  change public runtime behaviour, CLI commands, or library APIs.
+- [x] (2026-06-01T21:44:55Z) Documentation validation passed with
+  `make markdownlint` and `make nixie`. `make fmt` was attempted but failed on
+  pre-existing repository-wide Markdown line-length findings outside this
+  change; unrelated formatter edits were restored.
+- [x] (2026-06-01T21:44:55Z) Documentation milestone gate passed before
+  commit: `make check-fmt`, `make lint`, `make typecheck`, `make test`,
+  `make markdownlint`, `make nixie`, and `mbake validate Makefile` all exit
+  `0`; tests report 809 passed, 11 skipped, and 24 warnings.
 - [ ] Implement Hecate adoption after approval.
 - [ ] Validate implementation with local gates, CodeRabbit, and review.
 - [ ] Mark the relevant roadmap entry done only after implementation is
@@ -161,12 +187,12 @@ making changes.
 ## Surprises & discoveries
 
 - Observation: The repository does not currently contain a dedicated
-  automated hexagonal architecture check. Evidence: Searches across
-  `Makefile`, `.github`, `scripts`, `tests`, `ghillie`, and `docs` found
-  protocol and behaviour tests, but no Hecate, check-architecture target,
-  or import-boundary script. Impact: The migration is best treated as adding
-  a new canonical static gate and retiring only any future-discovered
-  structural assertions, not as a one-for-one script replacement.
+  automated hexagonal architecture check. Evidence: Searches across `Makefile`,
+  `.github`, `scripts`, `tests`, `ghillie`, and `docs` found protocol and
+  behaviour tests, but no Hecate, check-architecture target, or import-boundary
+  script. Impact: The migration is best treated as adding a new canonical
+  static gate and retiring only any future-discovered structural assertions,
+  not as a one-for-one script replacement.
 
 - Observation: One reconnaissance pass initially found report correctness
   checks rather than architecture-boundary checks. Evidence: The referenced
@@ -177,13 +203,20 @@ making changes.
 
 - Observation: Hecate `0.1.0` at
   `46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12` declares an unbounded
-  `Requires-Dist: cyclopts`, but its CLI uses `cyclopts.App(...,
-  result_action=...)`. Evidence: the first local `make check-architecture`
-  run raised `TypeError: App.__init__() got an unexpected keyword argument
-  'result_action'` with Cyclopts `2.9.9`; preserving Cyclopts `2.9.9` then
-  failed on callable `cyclopts.Parameter`. Impact: this adoption needs a
-  Cyclopts 3 compatibility update plus a shim until Hecate's declared
-  dependency range and CLI code are aligned.
+  `Requires-Dist: cyclopts`, but its CLI uses
+  `cyclopts.App(..., result_action=...)`. Evidence: the first local
+  `make check-architecture` run raised
+  `TypeError: App.__init__() got an unexpected keyword argument 'result_action'`
+  with Cyclopts `2.9.9`; preserving Cyclopts `2.9.9` then failed on callable
+  `cyclopts.Parameter`. Impact: this adoption needs a Cyclopts 3 compatibility
+  update plus a shim until Hecate's declared dependency range and CLI code are
+  aligned.
+
+- Observation: Stage C did not identify an existing repository-local
+  architecture test to delete. Evidence: the candidate tests assert runtime
+  behaviour and public contracts rather than parsing imports or enforcing layer
+  direction. Impact: Hecate adoption adds a new canonical static gate and keeps
+  the existing behaviour coverage intact.
 
 ## Decision log
 
@@ -220,6 +253,11 @@ making changes.
   2.9. Cyclopts 3 satisfies Hecate's callable `Parameter` usage, and the
   wrapper removes the remaining unsupported `result_action` keyword before
   importing Hecate's CLI. Date/Author: 2026-06-01T21:44:55Z / AI-proposed.
+
+- Decision: Do not update `docs/users-guide.md` for this adoption. Rationale:
+  the new gate is a developer and CI practice. It does not change Ghillie's
+  runtime behaviour, public Python APIs, HTTP routes, CLI command surface, or
+  user configuration. Date/Author: 2026-06-01T21:44:55Z / AI-proposed.
 
 ## Outcomes & retrospective
 
@@ -312,9 +350,9 @@ The exact policy may differ after inventory. If a module is both a port and an
 adapter today, record that ambiguity in the decision log before choosing a
 group.
 
-Stage A validation is documentary: update this plan with any discoveries and
-do not proceed if the group map is ambiguous enough to change public
-behaviour or require broad refactoring.
+Stage A validation is documentary: update this plan with any discoveries and do
+not proceed if the group map is ambiguous enough to change public behaviour or
+require broad refactoring.
 
 ### Stage B: add the Hecate gate
 

--- a/docs/execplans/adopt-hecate.md
+++ b/docs/execplans/adopt-hecate.md
@@ -4,10 +4,11 @@ This ExecPlan (execution plan) is a living document. The sections `Constraints`,
 `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: IMPLEMENTING
+Status: COMPLETE
 
 The user approved implementation on 2026-06-01. The branch now carries the
-plan, prior review material, and incremental implementation commits.
+plan, prior review material, the Hecate architecture gate, documentation
+updates, validation results, and incremental implementation commits.
 
 ## Purpose / big picture
 
@@ -179,10 +180,15 @@ making changes.
   commit: `make check-fmt`, `make lint`, `make typecheck`, `make test`,
   `make markdownlint`, `make nixie`, and `mbake validate Makefile` all exit
   `0`; tests report 809 passed, 11 skipped, and 24 warnings.
-- [ ] Implement Hecate adoption after approval.
-- [ ] Validate implementation with local gates, CodeRabbit, and review.
-- [ ] Mark the relevant roadmap entry done only after implementation is
-  complete.
+- [x] (2026-06-01T22:08:04Z) Committed the documentation and roadmap milestone
+  as `6e60b16 Document Hecate architecture checks`.
+- [x] (2026-06-01T22:08:04Z) Ran `coderabbit review --agent` after the
+  documentation milestone gates; CodeRabbit reported 0 findings.
+- [x] (2026-06-01T22:08:04Z) Implemented Hecate adoption after approval.
+- [x] (2026-06-01T22:08:04Z) Validated implementation with local gates,
+  CodeRabbit, and review.
+- [x] (2026-06-01T22:08:04Z) Marked the relevant roadmap entry done after
+  implementation, validation, and review.
 
 ## Surprises & discoveries
 
@@ -261,7 +267,23 @@ making changes.
 
 ## Outcomes & retrospective
 
-Implementation is in progress. No final outcome exists yet.
+Implementation is complete.
+
+Ghillie now pins Hecate to
+`46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12`, stores the import-direction policy
+in `[tool.hecate]`, exposes `make check-architecture`, and runs that gate before
+Ruff through `make lint` and CI. The pinned Hecate CLI requires Cyclopts 3 and a
+small repository wrapper for the remaining `result_action` compatibility gap.
+
+No public Ghillie CLI command, HTTP route, Python API, storage schema, runtime
+configuration, or user-facing behaviour changed. Existing behaviour tests were
+kept because the Stage C review found no tests that solely duplicated Hecate's
+static import-boundary responsibility.
+
+Validation completed with `make check-fmt`, `make lint`, `make typecheck`,
+`make test`, `make markdownlint`, `make nixie`, and
+`mbake validate Makefile`, all exiting `0`. CodeRabbit reviewed both the Hecate
+gate milestone and the documentation milestone with 0 findings.
 
 ## Context and orientation
 

--- a/docs/execplans/adopt-hecate.md
+++ b/docs/execplans/adopt-hecate.md
@@ -5,10 +5,10 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: IMPLEMENTING
 
-This plan must be explicitly approved before implementation starts. The current
-branch carries only the plan and review material.
+The user approved implementation on 2026-06-01. The branch now carries the
+plan, prior review material, and incremental implementation commits.
 
 ## Purpose / big picture
 
@@ -101,6 +101,14 @@ making changes.
   existing `uv` dependency workflow, commit the lockfile update if one is
   produced, and validate in a clean `make build`.
 
+- Risk: Hecate's pinned CLI uses Cyclopts APIs that are incompatible with
+  Ghillie's previous `cyclopts>=2.9,<3` runtime constraint, while Cyclopts
+  `3.24.0` still lacks Hecate's `result_action` keyword. Severity: medium.
+  Likelihood: high. Mitigation: update the existing Cyclopts dependency to
+  `cyclopts>=3,<4` and run Hecate through a narrow repository-local
+  compatibility wrapper that strips only the unsupported keyword before
+  importing Hecate's CLI.
+
 - Risk: developers may not know how to update the policy when adding modules.
   Severity: medium. Likelihood: medium. Mitigation: update
   `docs/developers-guide.md` with the new gate, group ordering convention, and
@@ -120,7 +128,31 @@ making changes.
 - [x] (2026-05-24T19:03:55Z) Confirmed there is no existing `hecate` target,
   dedicated check-architecture target, or repo-local check-architecture script.
 - [x] (2026-05-24T19:03:55Z) Drafted this pre-implementation ExecPlan.
-- [ ] Obtain approval for this ExecPlan before implementation.
+- [x] (2026-06-01T21:44:55Z) User approved implementation and requested work
+  proceed from this ExecPlan.
+- [x] (2026-06-01T21:44:55Z) Reloaded `leta` and
+  `hexagonal-architecture`, confirmed the Leta workspace already exists, and
+  re-opened the pinned Hecate documentation.
+- [x] (2026-06-01T21:44:55Z) Added the pinned Hecate dependency, initial
+  `[tool.hecate]` policy, `make check-architecture`, and CI lint-step naming
+  update.
+- [x] (2026-06-01T21:44:55Z) Ran `make build`; it installed Hecate from the
+  pinned commit and updated the lockfile.
+- [x] (2026-06-01T21:44:55Z) First `make check-architecture` attempt failed
+  before checking imports because Hecate's CLI passes `result_action` to
+  Cyclopts while Ghillie still constrained Cyclopts to `<3`.
+- [x] (2026-06-01T21:44:55Z) Tested preserving Cyclopts `2.9.9`; this failed
+  because Hecate also uses callable `cyclopts.Parameter`, which is unavailable
+  in that version.
+- [x] (2026-06-01T21:44:55Z) Updated the existing Cyclopts dependency to
+  `cyclopts>=3,<4` and kept `scripts/check_architecture.py` for the remaining
+  `result_action` compatibility gap.
+- [x] (2026-06-01T21:44:55Z) Stage B validation passed:
+  `make build`, `make check-architecture`, and `make lint` all exit `0`.
+- [x] (2026-06-01T21:44:55Z) Milestone gate passed before commit:
+  `make check-fmt`, `make lint`, `make typecheck`, `make test`,
+  `make markdownlint`, `make nixie`, and `mbake validate Makefile` all
+  exit `0`; tests report 809 passed, 11 skipped, and 24 warnings.
 - [ ] Implement Hecate adoption after approval.
 - [ ] Validate implementation with local gates, CodeRabbit, and review.
 - [ ] Mark the relevant roadmap entry done only after implementation is
@@ -142,6 +174,16 @@ making changes.
   report validation text, which cover LLM report validation, not Python import
   boundaries. Impact: Do not update report correctness behaviour unless
   implementation work independently touches it.
+
+- Observation: Hecate `0.1.0` at
+  `46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12` declares an unbounded
+  `Requires-Dist: cyclopts`, but its CLI uses `cyclopts.App(...,
+  result_action=...)`. Evidence: the first local `make check-architecture`
+  run raised `TypeError: App.__init__() got an unexpected keyword argument
+  'result_action'` with Cyclopts `2.9.9`; preserving Cyclopts `2.9.9` then
+  failed on callable `cyclopts.Parameter`. Impact: this adoption needs a
+  Cyclopts 3 compatibility update plus a shim until Hecate's declared
+  dependency range and CLI code are aligned.
 
 ## Decision log
 
@@ -167,10 +209,21 @@ making changes.
   retry semantics, or storage effects. Date/Author: 2026-05-24T19:03:55Z /
   AI-proposed.
 
+- Decision: Proceed with implementation on this branch. Rationale: The user
+  explicitly requested implementation of `docs/execplans/adopt-hecate.md` on
+  2026-06-01, satisfying the plan approval constraint. Date/Author:
+  2026-06-01T21:44:55Z / User-approved, AI-recorded.
+
+- Decision: Raise Ghillie's existing Cyclopts constraint from `>=2.9,<3` to
+  `>=3,<4` and call Hecate through `scripts/check_architecture.py`. Rationale:
+  Hecate is the only new dependency, but the pinned CLI cannot run on Cyclopts
+  2.9. Cyclopts 3 satisfies Hecate's callable `Parameter` usage, and the
+  wrapper removes the remaining unsupported `result_action` keyword before
+  importing Hecate's CLI. Date/Author: 2026-06-01T21:44:55Z / AI-proposed.
+
 ## Outcomes & retrospective
 
-The plan is currently drafted and awaiting approval. No implementation outcome
-exists yet.
+Implementation is in progress. No final outcome exists yet.
 
 ## Context and orientation
 
@@ -540,11 +593,19 @@ domain and port modules do not import adapters; application modules depend on
 ports and other application modules; adapters depend inward on application and
 ports; composition roots may wire across groups.
 
-The Makefile interface must be:
+The Makefile interface was expected to be:
 
 ```make
 check-architecture: build ## Run hexagonal architecture import checks
 	$(UV_ENV) uv run hecate check --show-ignored --fail-on-unmatched-ignore
+```
+
+Implementation uses this equivalent repository wrapper because the pinned
+Hecate CLI passes a Cyclopts keyword unsupported by Cyclopts `3.24.0`:
+
+```make
+check-architecture: build ## Run hexagonal architecture import checks
+	$(UV_ENV) uv run scripts/check_architecture.py
 ```
 
 The dependency must be pinned exactly:

--- a/docs/ghillie-bronze-silver-architecture-design.md
+++ b/docs/ghillie-bronze-silver-architecture-design.md
@@ -309,11 +309,11 @@ flowchart LR
 ```
 
 Static architecture checks treat Bronze and Silver transformation services as
-application modules and their SQLAlchemy model/storage modules as outbound
-adapters. This reflects the current implementation: services orchestrate
-domain-specific ingestion and transformation work, while storage modules own
-database table definitions and initialization. Keep this classification in
-`[tool.hecate]` current when adding Bronze or Silver modules.
+application modules and `ghillie.bronze.storage` and `ghillie.silver.storage`
+as outbound storage adapters. This reflects the current implementation:
+services orchestrate domain-specific ingestion and transformation work, while
+storage modules own database table definitions and initialization. Keep this
+classification in `[tool.hecate]` current when adding Bronze or Silver modules.
 
 ______________________________________________________________________
 

--- a/docs/ghillie-bronze-silver-architecture-design.md
+++ b/docs/ghillie-bronze-silver-architecture-design.md
@@ -308,6 +308,13 @@ flowchart LR
 
 ```
 
+Static architecture checks treat Bronze and Silver transformation services as
+application modules and their SQLAlchemy model/storage modules as outbound
+adapters. This reflects the current implementation: services orchestrate
+domain-specific ingestion and transformation work, while storage modules own
+database table definitions and initialization. Keep this classification in
+`[tool.hecate]` current when adding Bronze or Silver modules.
+
 ______________________________________________________________________
 
 ## 3. Database schemas

--- a/docs/ghillie-bronze-silver-architecture-design.md
+++ b/docs/ghillie-bronze-silver-architecture-design.md
@@ -308,11 +308,13 @@ flowchart LR
 
 ```
 
-Static architecture checks treat Bronze and Silver transformation services as
-application modules and `ghillie.bronze.storage` and `ghillie.silver.storage`
-as outbound storage adapters. This reflects the current implementation:
-services orchestrate domain-specific ingestion and transformation work, while
-storage modules own database table definitions and initialization. Keep this
+Static architecture checks treat Bronze and Silver transformation services and
+errors as application modules, including `ghillie.bronze.errors` and
+`ghillie.silver.errors`; `ghillie.bronze.storage` and
+`ghillie.silver.storage` remain outbound storage adapters. This reflects the
+current implementation: services orchestrate domain-specific ingestion and
+transformation work, errors define application failure contracts, and storage
+modules own database table definitions and initialization. Keep this
 classification in `[tool.hecate]` current when adding Bronze or Silver modules.
 
 ______________________________________________________________________

--- a/docs/ghillie-design.md
+++ b/docs/ghillie-design.md
@@ -713,6 +713,14 @@ This structure maintains clear separation between:
 - **Outbound adapters** (status queries, on-demand reports): Read/write path
   to Gold layer
 
+Static import-direction drift is enforced with Hecate. The repository policy
+lives in `[tool.hecate]` in `pyproject.toml` and is exposed through
+`make check-architecture`, which runs before Ruff as part of `make lint`. Hecate
+classifies modules into composition roots, domain ports, application modules,
+inbound adapters, and outbound adapters. The decision and rollback path are
+recorded in
+`docs/adr-003-adopt-hecate-for-architecture-checks.md`.
+
 **Design decisions:**
 
 - Health probe endpoints remain in a separate resource module from domain

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -225,6 +225,19 @@ ephemeral previews platform and supports the Ghillie Helm chart.
   *Completion criteria:* The users' guide includes a local preview section with
   validated commands and expected outcomes.
 
+### Step 1.6: Guard architecture boundaries
+
+**Goal:** Make architecture drift visible before it reaches review or CI.
+
+- [x] **Task 1.6.a – Adopt Hecate architecture checks**
+  Add Hecate as the repository's static import-direction gate for the
+  hexagonal architecture policy.
+
+  *Completion criteria:* `make check-architecture` runs the pinned Hecate
+  checker against `[tool.hecate]`, `make lint` runs the architecture gate
+  before Ruff, CI uses the combined lint target, and the adoption is recorded
+  in ADR-003.
+
 ______________________________________________________________________
 
 ## Phase 2: Deliver repository-level status reporting (MVP)

--- a/ghillie/catalogue/storage.py
+++ b/ghillie/catalogue/storage.py
@@ -33,8 +33,6 @@ if typ.TYPE_CHECKING:
 class Base(DeclarativeBase):
     """Base declarative class for catalogue persistence."""
 
-    metadata: typ.Any
-
 
 class Estate(Base):
     """Logical grouping of projects under management."""

--- a/ghillie/reporting/metrics_service.py
+++ b/ghillie/reporting/metrics_service.py
@@ -282,7 +282,8 @@ class ReportingMetricsService:
             ).where(Repository.estate_id == estate_id)
 
         async with self._session_factory() as session:
-            rows: typ.Sequence[MetricsRow] = (
-                (await session.execute(stmt)).tuples().all()
+            rows = typ.cast(
+                "list[MetricsRow]",
+                (await session.execute(stmt)).tuples().all(),
             )
-        return list(rows)
+        return rows  # noqa: RET504

--- a/ghillie/reporting/metrics_service.py
+++ b/ghillie/reporting/metrics_service.py
@@ -282,5 +282,7 @@ class ReportingMetricsService:
             ).where(Repository.estate_id == estate_id)
 
         async with self._session_factory() as session:
-            rows = (await session.execute(stmt)).tuples().all()
+            rows: typ.Sequence[MetricsRow] = (
+                (await session.execute(stmt)).tuples().all()
+            )
         return list(rows)

--- a/ghillie/reporting/metrics_service.py
+++ b/ghillie/reporting/metrics_service.py
@@ -283,4 +283,4 @@ class ReportingMetricsService:
 
         async with self._session_factory() as session:
             rows = (await session.execute(stmt)).tuples().all()
-        return [typ.cast("MetricsRow", row) for row in rows]
+        return list(rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "httpx>=0.27.0",
     "falcon>=4.0.0,<5.0.0",
     "granian>=1.0.0,<3.0.0",
-    "cyclopts>=2.9,<3",
+    "cyclopts>=3,<4",
 ]
 
 [project.scripts]
@@ -33,6 +33,7 @@ ghillie = "ghillie.cli:main"
 
 [dependency-groups]
 dev = [
+    "hecate @ git+https://github.com/leynos/hecate@46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12",
     "hypothesis>=6.150.0,<7",
     "pytest",
     "pytest-bdd",
@@ -148,6 +149,117 @@ markers = [
 
 [tool.uv]
 package = true
+
+[tool.hecate]
+root_packages = ["ghillie"]
+
+[[tool.hecate.groups]]
+name = "composition_root"
+prefixes = [
+    "ghillie.api.app",
+    "ghillie.api.factory",
+    "ghillie.cli.app",
+    "ghillie.reporting.actor",
+    "ghillie.runtime",
+    "ghillie.status.factory",
+]
+allowed = [
+    "application",
+    "composition_root",
+    "domain_ports",
+    "inbound_adapter",
+    "outbound_adapter",
+]
+
+[[tool.hecate.groups]]
+name = "domain_ports"
+prefixes = [
+    "ghillie.common",
+    "ghillie.catalogue.models",
+    "ghillie.evidence.models",
+    "ghillie.registry.models",
+    "ghillie.reporting.sink",
+    "ghillie.status.metrics",
+    "ghillie.status.models",
+    "ghillie.status.protocol",
+]
+allowed = ["domain_ports"]
+
+[[tool.hecate.groups]]
+name = "application"
+prefixes = [
+    "ghillie.bronze.errors",
+    "ghillie.bronze.services",
+    "ghillie.catalogue.importer",
+    "ghillie.catalogue.loader",
+    "ghillie.catalogue.schema",
+    "ghillie.catalogue.validation",
+    "ghillie.catalogue.watch",
+    "ghillie.evidence.classification",
+    "ghillie.evidence.event_targets",
+    "ghillie.evidence.project_service",
+    "ghillie.evidence.service",
+    "ghillie.github.errors",
+    "ghillie.github.ingestion",
+    "ghillie.github.lag",
+    "ghillie.github.models",
+    "ghillie.github.noise",
+    "ghillie.github.observability",
+    "ghillie.logging",
+    "ghillie.registry",
+    "ghillie.reporting.config",
+    "ghillie.reporting.errors",
+    "ghillie.reporting.markdown",
+    "ghillie.reporting.metrics_service",
+    "ghillie.reporting.observability",
+    "ghillie.reporting.service",
+    "ghillie.reporting.validation",
+    "ghillie.silver.errors",
+    "ghillie.silver.services",
+    "ghillie.silver.transformers",
+    "ghillie.status.config",
+    "ghillie.status.constants",
+    "ghillie.status.errors",
+    "ghillie.status.prompts",
+]
+allowed = [
+    "application",
+    "domain_ports",
+    "outbound_adapter",
+]
+
+[[tool.hecate.groups]]
+name = "inbound_adapter"
+prefixes = [
+    "ghillie.api",
+    "ghillie.catalogue.cli",
+    "ghillie.cli",
+]
+allowed = [
+    "application",
+    "composition_root",
+    "domain_ports",
+    "inbound_adapter",
+    "outbound_adapter",
+]
+
+[[tool.hecate.groups]]
+name = "outbound_adapter"
+prefixes = [
+    "ghillie.bronze.storage",
+    "ghillie.catalogue.storage",
+    "ghillie.github.client",
+    "ghillie.gold.storage",
+    "ghillie.reporting.filesystem_sink",
+    "ghillie.silver.storage",
+    "ghillie.status.mock",
+    "ghillie.status.openai_client",
+]
+allowed = [
+    "application",
+    "domain_ports",
+    "outbound_adapter",
+]
 
 [tool.setuptools.packages.find]
 include = ["ghillie*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ prefixes = [
     "ghillie.github.noise",
     "ghillie.github.observability",
     "ghillie.logging",
-    "ghillie.registry",
+    "ghillie.registry",  # generic — all ghillie.registry.* leaf entries must precede this
     "ghillie.reporting.config",
     "ghillie.reporting.errors",
     "ghillie.reporting.markdown",
@@ -236,7 +236,7 @@ name = "inbound_adapter"
 # Keep composition-root prefixes such as ghillie.api.app and
 # ghillie.api.factory above this generic ghillie.api adapter prefix.
 prefixes = [
-    "ghillie.api",
+    "ghillie.api",  # generic — ghillie.api.app and ghillie.api.factory must remain above this
     "ghillie.catalogue.cli",
     "ghillie.cli",
 ]
@@ -272,8 +272,8 @@ name = "package_facade"
 # Package facades re-export mixed boundary objects. Keep this group after all
 # leaf-module groups so it catches only ghillie.status and ghillie.reporting.
 prefixes = [
-    "ghillie.reporting",
-    "ghillie.status",
+    "ghillie.reporting",  # generic — all ghillie.reporting.* leaf entries must precede this
+    "ghillie.status",  # generic — all ghillie.status.* leaf entries must precede this
 ]
 allowed = [
     "application",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,8 @@ allowed = ["domain_ports"]
 
 [[tool.hecate.groups]]
 name = "application"
+# Hecate uses first-match semantics. Keep narrower prefixes above generic
+# package prefixes such as ghillie.registry.
 prefixes = [
     "ghillie.bronze.errors",
     "ghillie.bronze.services",
@@ -230,6 +232,8 @@ allowed = [
 
 [[tool.hecate.groups]]
 name = "inbound_adapter"
+# Keep composition-root prefixes such as ghillie.api.app and
+# ghillie.api.factory above this generic ghillie.api adapter prefix.
 prefixes = [
     "ghillie.api",
     "ghillie.catalogue.cli",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ allowed = [
     "domain_ports",
     "inbound_adapter",
     "outbound_adapter",
+    "package_facade",
 ]
 
 [[tool.hecate.groups]]
@@ -245,6 +246,7 @@ allowed = [
     "domain_ports",
     "inbound_adapter",
     "outbound_adapter",
+    "package_facade",
 ]
 
 [[tool.hecate.groups]]
@@ -262,6 +264,22 @@ prefixes = [
 allowed = [
     "application",
     "domain_ports",
+    "outbound_adapter",
+]
+
+[[tool.hecate.groups]]
+name = "package_facade"
+# Package facades re-export mixed boundary objects. Keep this group after all
+# leaf-module groups so it catches only ghillie.status and ghillie.reporting.
+prefixes = [
+    "ghillie.reporting",
+    "ghillie.status",
+]
+allowed = [
+    "application",
+    "composition_root",
+    "domain_ports",
+    "inbound_adapter",
     "outbound_adapter",
 ]
 

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -8,6 +8,7 @@ dependency range.
 """
 
 import typing as typ
+from contextlib import contextmanager
 
 import cyclopts
 
@@ -17,18 +18,26 @@ _OriginalApp: typ.Any = cyclopts.App
 def _compat_app(*args: object, **kwargs: object) -> cyclopts.App:
     """Ignore Hecate's unsupported Cyclopts keyword during app construction."""
     kwargs.pop("result_action", None)
-    return typ.cast(
-        "cyclopts.App",
-        _OriginalApp(*typ.cast("typ.Any", args), **typ.cast("typ.Any", kwargs)),
-    )
+    return typ.cast("cyclopts.App", _OriginalApp(*args, **kwargs))
+
+
+@contextmanager
+def _patched_cyclopts_app() -> typ.Iterator[None]:
+    """Temporarily install the Hecate compatibility constructor."""
+    original_app = cyclopts.App
+    cyclopts.App = typ.cast("typ.Any", _compat_app)
+    try:
+        yield
+    finally:
+        cyclopts.App = original_app
 
 
 def main() -> int:
     """Run the Hecate CLI entry point with repository defaults."""
-    cyclopts.App = typ.cast("typ.Any", _compat_app)
-    from hecate.cli import main as hecate_main
+    with _patched_cyclopts_app():
+        from hecate.cli import main as hecate_main
 
-    return hecate_main(["check", "--show-ignored", "--fail-on-unmatched-ignore"])
+        return hecate_main(["check", "--show-ignored", "--fail-on-unmatched-ignore"])
 
 
 if __name__ == "__main__":

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -1,0 +1,35 @@
+"""Run Hecate with the Cyclopts version supported by Ghillie.
+
+The pinned Hecate commit constructs ``cyclopts.App`` with ``result_action``.
+Ghillie's supported Cyclopts range does not accept that keyword, but Hecate's
+checker and command implementation do not otherwise depend on it. This wrapper
+keeps the dependency pin intact while preserving Ghillie's existing CLI
+dependency range.
+"""
+
+import typing as typ
+
+import cyclopts
+
+_OriginalApp: typ.Any = cyclopts.App
+
+
+def _compat_app(*args: object, **kwargs: object) -> cyclopts.App:
+    """Ignore Hecate's unsupported Cyclopts keyword during app construction."""
+    kwargs.pop("result_action", None)
+    return typ.cast(
+        "cyclopts.App",
+        _OriginalApp(*typ.cast("typ.Any", args), **typ.cast("typ.Any", kwargs)),
+    )
+
+
+def main() -> int:
+    """Run the Hecate CLI entry point with repository defaults."""
+    cyclopts.App = typ.cast("typ.Any", _compat_app)
+    from hecate.cli import main as hecate_main
+
+    return hecate_main(["check", "--show-ignored", "--fail-on-unmatched-ignore"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -15,17 +15,17 @@ import cyclopts
 _OriginalApp: typ.Any = cyclopts.App
 
 
-def _compat_app(*args: object, **kwargs: object) -> cyclopts.App:
+def _compat_app(*args: typ.Any, **kwargs: typ.Any) -> cyclopts.App:  # noqa: ANN401
     """Ignore Hecate's unsupported Cyclopts keyword during app construction."""
     kwargs.pop("result_action", None)
-    return typ.cast("cyclopts.App", _OriginalApp(*args, **kwargs))
+    return _OriginalApp(*args, **kwargs)  # type: ignore[return-value]
 
 
 @contextmanager
 def _patched_cyclopts_app() -> typ.Iterator[None]:
     """Temporarily install the Hecate compatibility constructor."""
     original_app = cyclopts.App
-    cyclopts.App = typ.cast("typ.Any", _compat_app)
+    cyclopts.App = _compat_app  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     try:
         yield
     finally:

--- a/scripts/tests/test_check_architecture.py
+++ b/scripts/tests/test_check_architecture.py
@@ -1,0 +1,151 @@
+"""Unit tests for the ``check_architecture`` Hecate compatibility wrapper.
+
+The wrapper exists because the pinned Hecate commit constructs
+``cyclopts.App`` with a ``result_action`` keyword that Ghillie's supported
+Cyclopts range does not accept. Importing ``hecate`` (and therefore
+``hecate.cli``) fails outside the compatibility patch, so the few tests that
+need ``hecate.cli`` load it via the ``hecate_cli`` fixture, which imports the
+module *inside* the patched context and skips when Hecate is not installed.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from unittest import mock
+
+import check_architecture
+import cyclopts
+import pytest
+
+if typ.TYPE_CHECKING:
+    from types import ModuleType
+
+
+@pytest.fixture
+def hecate_cli() -> ModuleType:
+    """Load ``hecate.cli`` under the compatibility patch.
+
+    Importing ``hecate`` without the patch raises ``TypeError`` because of the
+    unsupported ``result_action`` keyword, so the import is performed inside
+    :func:`check_architecture._patched_cyclopts_app`. When Hecate is not
+    installed the import raises ``ModuleNotFoundError`` and the test is
+    skipped.
+    """
+    with check_architecture._patched_cyclopts_app():
+        return pytest.importorskip("hecate.cli")
+
+
+class TestCompatApp:
+    """Tests for the ``_compat_app`` constructor shim."""
+
+    def test_compat_app_removes_result_action(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``result_action`` is stripped while other keywords pass through."""
+        captured = mock.MagicMock()
+        monkeypatch.setattr(check_architecture, "_OriginalApp", captured)
+
+        check_architecture._compat_app(result_action="ignored", name="hecate")
+
+        captured.assert_called_once()
+        _, kwargs = captured.call_args
+        assert "result_action" not in kwargs, "result_action must not be forwarded"
+        assert kwargs["name"] == "hecate", "other keywords must be forwarded"
+
+    def test_compat_app_passes_positional_args(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Positional arguments reach the underlying constructor unchanged."""
+        captured = mock.MagicMock()
+        monkeypatch.setattr(check_architecture, "_OriginalApp", captured)
+
+        check_architecture._compat_app("alpha", "beta")
+
+        captured.assert_called_once()
+        args, _ = captured.call_args
+        assert args == ("alpha", "beta"), "positional args must be forwarded unchanged"
+
+    def test_compat_app_no_result_action_is_noop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without ``result_action`` the keywords are forwarded intact."""
+        captured = mock.MagicMock()
+        monkeypatch.setattr(check_architecture, "_OriginalApp", captured)
+
+        check_architecture._compat_app(name="hecate", help="docs")
+
+        captured.assert_called_once()
+        _, kwargs = captured.call_args
+        assert kwargs == {"name": "hecate", "help": "docs"}, (
+            "keywords must be forwarded intact"
+        )
+
+
+class TestPatchedCycloptsApp:
+    """Tests for the ``_patched_cyclopts_app`` context manager."""
+
+    def test_patched_cyclopts_app_installs_compat(self) -> None:
+        """Inside the context ``cyclopts.App`` is the compatibility shim."""
+        with check_architecture._patched_cyclopts_app():
+            assert cyclopts.App is check_architecture._compat_app, (
+                "compat constructor should be installed inside the context"
+            )
+
+    def test_patched_cyclopts_app_restores_original(self) -> None:
+        """After a normal exit ``cyclopts.App`` is restored."""
+        with check_architecture._patched_cyclopts_app():
+            pass
+
+        assert cyclopts.App is check_architecture._OriginalApp, (
+            "original App should be restored after the context exits"
+        )
+
+    def test_patched_cyclopts_app_restores_on_exception(self) -> None:
+        """``cyclopts.App`` is restored even when the body raises."""
+        sentinel = RuntimeError("boom")
+        with (
+            pytest.raises(RuntimeError, match="boom"),
+            check_architecture._patched_cyclopts_app(),
+        ):
+            raise sentinel
+
+        assert cyclopts.App is check_architecture._OriginalApp, (
+            "original App should be restored after an exception"
+        )
+
+
+class TestMain:
+    """Tests for the ``main`` entry point."""
+
+    def test_main_calls_hecate_with_correct_args(
+        self, monkeypatch: pytest.MonkeyPatch, hecate_cli: ModuleType
+    ) -> None:
+        """``main`` invokes the Hecate CLI with the repository defaults."""
+        hecate_main = mock.MagicMock(return_value=0)
+        monkeypatch.setattr(hecate_cli, "main", hecate_main)
+
+        check_architecture.main()
+
+        hecate_main.assert_called_once_with(
+            ["check", "--show-ignored", "--fail-on-unmatched-ignore"]
+        )
+
+    def test_main_returns_hecate_exit_code(
+        self, monkeypatch: pytest.MonkeyPatch, hecate_cli: ModuleType
+    ) -> None:
+        """``main`` returns the Hecate CLI exit code verbatim."""
+        monkeypatch.setattr(hecate_cli, "main", mock.MagicMock(return_value=42))
+
+        assert check_architecture.main() == 42, "exit code must be propagated"
+
+    def test_main_restores_cyclopts_after_hecate_call(
+        self, monkeypatch: pytest.MonkeyPatch, hecate_cli: ModuleType
+    ) -> None:
+        """``cyclopts.App`` is restored once ``main`` returns."""
+        monkeypatch.setattr(hecate_cli, "main", mock.MagicMock(return_value=0))
+
+        check_architecture.main()
+
+        assert cyclopts.App is check_architecture._OriginalApp, (
+            "original App should be restored after main runs"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -103,18 +103,17 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "2.9.9"
+version = "3.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "docstring-parser", marker = "python_full_version < '4'" },
     { name = "rich" },
     { name = "rich-rst" },
-    { name = "typing-extensions", marker = "python_full_version < '4'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/b6/51022d8b673087262c4bcd1e64c1db3a8ab01510033f7f82a561998e3499/cyclopts-2.9.9.tar.gz", hash = "sha256:11d7bb59be253329ff49a1b9a634676c7ae708605d4975090783b99d081c1a0b", size = 45179, upload-time = "2024-08-27T21:14:47.137Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/ca/7782da3b03242d5f0a16c20371dff99d4bd1fedafe26bc48ff82e42be8c9/cyclopts-3.24.0.tar.gz", hash = "sha256:de6964a041dfb3c57bf043b41e68c43548227a17de1bad246e3a0bfc5c4b7417", size = 76131, upload-time = "2025-09-08T15:40:57.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/7c/f1af5b44f581df05009ecc9b15395532fc18c7aa7292b5e98501af25c2db/cyclopts-2.9.9-py3-none-any.whl", hash = "sha256:d0ce956c70f3070e5bc16824ecb5ebba155be45ef4aadbb78ac4753dd99367e3", size = 51062, upload-time = "2024-08-27T21:14:45.977Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/8b/2c95f0645c6f40211896375e6fa51f504b8ccb29c21f6ae661fe87ab044e/cyclopts-3.24.0-py3-none-any.whl", hash = "sha256:809d04cde9108617106091140c3964ee6fceb33cecdd537f7ffa360bde13ed71", size = 86154, upload-time = "2025-09-08T15:40:56.41Z" },
 ]
 
 [[package]]
@@ -208,6 +207,7 @@ dependencies = [
 dev = [
     { name = "asyncpg" },
     { name = "cmd-mox" },
+    { name = "hecate" },
     { name = "hypothesis" },
     { name = "plumbum" },
     { name = "py-pglite", extra = ["asyncpg"] },
@@ -225,7 +225,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
-    { name = "cyclopts", specifier = ">=2.9,<3" },
+    { name = "cyclopts", specifier = ">=3,<4" },
     { name = "dramatiq", specifier = ">=1.16.0" },
     { name = "falcon", specifier = ">=4.0.0,<5.0.0" },
     { name = "femtologging", git = "https://github.com/leynos/femtologging?rev=691a73962df8f99308a82348d99c4f707c245e63" },
@@ -240,6 +240,7 @@ requires-dist = [
 dev = [
     { name = "asyncpg", specifier = ">=0.20.0,<1.0" },
     { name = "cmd-mox", specifier = ">=0.2,<1" },
+    { name = "hecate", git = "https://github.com/leynos/hecate?rev=46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12" },
     { name = "hypothesis", specifier = ">=6.150.0,<7" },
     { name = "plumbum", specifier = ">=1.10,<2" },
     { name = "py-pglite", extras = ["asyncpg"], specifier = ">=0.1.0" },
@@ -308,6 +309,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hecate"
+version = "0.1.0"
+source = { git = "https://github.com/leynos/hecate?rev=46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12#46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12" }
+dependencies = [
+    { name = "cyclopts" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This branch implements the approved Hecate adoption plan for Ghillie's
hexagonal architecture checks. It adds Hecate pinned to
`46f8c8798e7a80a3a1ab5a13c2a000a4423ffc12`, stores the architecture policy in
`pyproject.toml`, exposes `make check-architecture`, and runs that gate before
Ruff through `make lint` and CI.

Roadmap task: (1.6) Guard architecture boundaries
ExecPlan: [docs/execplans/adopt-hecate.md](https://github.com/leynos/ghillie/blob/adopt-hecate/docs/execplans/adopt-hecate.md)

## Review walkthrough

- Start with [docs/execplans/adopt-hecate.md](https://github.com/leynos/ghillie/blob/adopt-hecate/docs/execplans/adopt-hecate.md) for the approved plan, recorded decisions, validation history, and completion notes.
- Review [pyproject.toml](https://github.com/leynos/ghillie/blob/adopt-hecate/pyproject.toml), [Makefile](https://github.com/leynos/ghillie/blob/adopt-hecate/Makefile), and [scripts/check_architecture.py](https://github.com/leynos/ghillie/blob/adopt-hecate/scripts/check_architecture.py) for the Hecate dependency, policy, Make target, and compatibility wrapper.
- Check [.github/workflows/ci.yml](https://github.com/leynos/ghillie/blob/adopt-hecate/.github/workflows/ci.yml) for the CI lint step wording that now covers architecture and Ruff checks.
- Read [docs/adr-003-adopt-hecate-for-architecture-checks.md](https://github.com/leynos/ghillie/blob/adopt-hecate/docs/adr-003-adopt-hecate-for-architecture-checks.md), [docs/developers-guide.md](https://github.com/leynos/ghillie/blob/adopt-hecate/docs/developers-guide.md), [docs/ghillie-design.md](https://github.com/leynos/ghillie/blob/adopt-hecate/docs/ghillie-design.md), and [docs/ghillie-bronze-silver-architecture-design.md](https://github.com/leynos/ghillie/blob/adopt-hecate/docs/ghillie-bronze-silver-architecture-design.md) for the design and contributor-facing documentation.
- Finish with [docs/roadmap.md](https://github.com/leynos/ghillie/blob/adopt-hecate/docs/roadmap.md) for the completed roadmap entry and the small typecheck fixes in [ghillie/catalogue/storage.py](https://github.com/leynos/ghillie/blob/adopt-hecate/ghillie/catalogue/storage.py) and [ghillie/reporting/metrics_service.py](https://github.com/leynos/ghillie/blob/adopt-hecate/ghillie/reporting/metrics_service.py).

## Validation

- `make build`: passed
- `make check-architecture`: passed
- `make check-fmt`: passed
- `make lint`: passed
- `make typecheck`: passed
- `make test`: passed, 809 passed, 11 skipped, 24 warnings
- `make markdownlint`: passed
- `make nixie`: passed
- `mbake validate Makefile`: passed
- `coderabbit review --agent` after the Hecate gate milestone: passed, 0 findings
- `coderabbit review --agent` after the documentation milestone: passed, 0 findings

## Notes

- The pinned Hecate CLI needs Cyclopts 3 for callable `cyclopts.Parameter`, but Cyclopts `3.24.0` does not support Hecate's `result_action` keyword. `scripts/check_architecture.py` is a narrow compatibility wrapper for that gap.
- No public Ghillie CLI command, HTTP route, Python API, storage schema, runtime configuration, or user-facing behaviour changed, so `docs/users-guide.md` was intentionally left unchanged.
- Existing behaviour tests were retained; Stage C found no tests that solely duplicated static import-boundary enforcement.

## References

- Lody session: https://lody.ai/leynos/sessions/9a262b6c-18f3-4aba-9e62-285e6acc9544

## Summary by Sourcery

Adopt Hecate as the static architecture checker, wiring it into development tooling and CI while documenting the new architecture gate and keeping runtime behaviour unchanged.

New Features:
- Introduce a Hecate-based architecture policy configured via [tool.hecate] in pyproject.toml to enforce hexagonal import boundaries.
- Add a make check-architecture target and run it ahead of Ruff in make lint and CI linting.

Enhancements:
- Bump Cyclopts dependency to the 3.x line and add a small compatibility wrapper script for running the pinned Hecate CLI.
- Clarify and extend developer and architecture documentation, including an ADR, execution plan, and design docs describing the new architecture checks and Bronze/Silver classifications.
- Mark the roadmap task for guarding architecture boundaries as complete.

CI:
- Update the CI workflow to run the combined architecture and lint checks via make lint.

Documentation:
- Document the Hecate architecture gate, its policy maintenance rules, and its role in the hexagonal design across developers guide, design docs, ADR-003, and an execution plan, and update the roadmap for the completed step.

Tests:
- Adjust minor type-related code in storage and reporting modules to satisfy existing type checks without changing behaviour.