### PR TITLE
Wire up CodeScene coverage upload and ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,15 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
-    env:
-      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # `cs-coverage check` (added in a follow-up once CodeScene's
+          # gates configuration is available for this project) diffs the
+          # PR against its merge base, so full history must stay
+          # reachable; this matches CodeScene's documented example.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -52,38 +55,24 @@ jobs:
       - name: Run typechecker
         run: make typecheck
 
-      - name: Run tests with coverage
-        run: |
-          uv pip install slipcover pytest-forked
-          uv run python -m slipcover \
-            --source=./ghillie \
-            --omit="*/unittests/*,*/.venv/*" \
-            --branch \
-            --out coverage.xml \
-            -m pytest --forked -v
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+      # Coverage is generated here only for pull requests; coverage-main.yml
+      # generates and uploads the authoritative main-branch coverage on
+      # push, so a push-triggered run of this job would otherwise generate
+      # coverage twice for the same commit.
+      #
+      # Uploading to CodeScene from the PR is deferred: `mode: check`
+      # requires a gates configuration that CodeScene has not yet enabled
+      # for this project (see ddlint#287 for the model). Once
+      # coverage-main.yml has fed the project an initial upload and the
+      # gates configuration appears, add a guarded `mode: check` step here.
+      - name: Generate coverage
+        if: github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          name: coverage
-          path: coverage.xml
+          format: cobertura
+          output-path: coverage.xml
+          with-ratchet: 'true'
 
-      - name: Install CodeScene Coverage CLI
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
-          if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-            echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
-          fi
-
-      - name: Upload coverage to CodeScene
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          if [ ! -f coverage.xml ]; then
-            echo "coverage.xml not found!"
-            exit 1
-          fi
-          cs-coverage upload \
-            --format "cobertura" \
-            --metric "line-coverage" \
-            coverage.xml
+      - name: Run tests
+        if: github.event_name != 'pull_request'
+        run: uv run pytest -v -n auto

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,48 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests generate
+# coverage with the ratchet only (ci.yml) until CodeScene's gates
+# configuration is available for this project (see ddlint#287). This
+# workflow also advances the coverage ratchet baseline: caches saved on
+# main are readable by every pull-request run, so the baseline written
+# here is the one PR ratchet checks compare against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          output-path: coverage.xml
+          with-ratchet: 'true'
+
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          path: coverage.xml
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1990e9a6aaa73f0929e04dbc7da12326005606bf
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       paths: "ghillie/"
       module-prefix-strip: ""

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -34,7 +34,7 @@ pytestmark = pytest.mark.skipif(
 
 #: The pinned commit of leynos/shared-actions providing
 #: mutation-mutmut.yml. Bump the workflow and this test together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

- Replace the bespoke slipcover invocation in `ci.yml` with the shared
  [`generate-coverage`](https://github.com/leynos/shared-actions/blob/927edd45ae77be4251a8a18ca9eb5613a2e32cbd/.github/actions/generate-coverage/action.yml)
  action, pinned at `927edd4` (shared-actions#334), keeping the
  existing cobertura format and enabling the coverage ratchet.
- Add [`coverage-main.yml`](https://github.com/leynos/ghillie/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml),
  which uploads coverage to CodeScene and advances the ratchet baseline
  on every push to `main` — CodeScene only accepts `cs-coverage upload`
  for branches it analyses.
- Bump the other `leynos/shared-actions` references in the repo
  ([`mutation-testing.yml`](https://github.com/leynos/ghillie/blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml),
  [`dependabot-automerge.yml`](https://github.com/leynos/ghillie/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml))
  to the same commit, and update the pinned SHA in
  [`tests/test_workflow_contract.py`](https://github.com/leynos/ghillie/blob/codescene-coverage-gate/tests/test_workflow_contract.py)
  so the whole repository carries one pin.
- The `cs-coverage check` pull-request gate is **not** wired up yet:
  CodeScene's `mode: check` requires a gates configuration that is not
  present for this project (CodeScene project 74419) today — only
  `mxd`'s project has it. A short comment in
  [`ci.yml`](https://github.com/leynos/ghillie/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  notes the deferral; it will be a small follow-up once CodeScene
  enables gates for this project.

## Review walkthrough

- `ci.yml`: the `lint-test` job now checks out with `fetch-depth: 0`
  (needed for the future `cs-coverage check` gate, and harmless now),
  and splits the old single coverage/upload block into:
  - `Generate coverage`, guarded to `pull_request` events only, which
    runs the shared action with `format: cobertura`,
    `output-path: coverage.xml`, and `with-ratchet: 'true'`. It does
    **not** upload — only the ratchet check runs on PRs.
  - `Run tests`, guarded to non-`pull_request` events (i.e. pushes to
    `main`), which just runs `uv run pytest -v -n auto` without
    coverage instrumentation — `coverage-main.yml` generates the
    authoritative main-branch coverage for the same commit, so
    generating it twice in `ci.yml` would be wasteful and would
    double-write the ratchet cache.
  - The previous bespoke `cs-coverage upload` step (unconditional, ungated by
    branch) is removed: it would have started failing the moment
    `CS_ACCESS_TOKEN` was set, because CodeScene only accepts uploads
    for `main`.
- `coverage-main.yml`: new workflow, triggered on `push: branches:
  [main]`. Generates cobertura coverage with the ratchet enabled
  (same shared action), then uploads to CodeScene via
  `upload-codescene-coverage` in the default `mode: upload`, guarded on
  `CS_ACCESS_TOKEN` being present so token-less runs (e.g. forks) skip
  cleanly.
- Deviation from the shared `generate-coverage` recipe: the action
  takes no `--source`/`--omit` scoping, so the previous
  `--source=./ghillie --omit="*/unittests/*,*/.venv/*"` scoping is
  lost — coverage will broaden to include everything pytest imports,
  including test code. Expect the ratchet baseline to land at a
  different (likely lower) percentage than before; this is a known
  estate-wide limitation of the shared action, not a regression
  specific to this change.
- Deviation: the previous coverage step used `pytest --forked` (via
  `pytest-forked`) for process isolation; the shared action's Python
  leg does not install `pytest-forked` and instead defaults to
  `pytest-xdist` (`-n auto`), matching how `make test` already runs
  the suite in this repo's Makefile. This is expected to be
  behaviour-preserving for ghillie specifically, since its normal test
  target already runs under xdist without `--forked`, but the CI run
  on this PR is the practical confirmation.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` against every file
  under `.github/workflows/` (all parse).
- `uv run pytest tests/test_workflow_contract.py -v` — all six
  contract tests pass against the bumped pin.
- CI on this PR's own head will confirm the `Generate coverage` step
  runs and the ratchet does not fail on the first (baseline-establishing)
  run.

Regarding the automerge/rollup mechanism: `codescene-access` currently
posts only a `CodeScene Code Health Review` check for this repository
(project 74419); it does not yet post a `CodeScene Code Coverage`
check, so this change cannot poison the status rollup the way an
unguarded, always-run upload step would once the secret exists
elsewhere in the estate. The only required check is `lint-test`.
