### PR TITLE
Fix artifact/artefact spelling drift in execplan docs

### DIFF
--- a/docs/execplans/1-5-b-ghillie-helm-chart-for-previews.md
+++ b/docs/execplans/1-5-b-ghillie-helm-chart-for-previews.md
@@ -414,7 +414,7 @@ If a step fails:
 - Re-run `helm lint` or `pytest` to verify.
 - No cleanup required; proceed from the failing step.
 
-## Artifacts and Notes
+## Artefacts and Notes
 
 ### Chart.yaml
 

--- a/docs/execplans/2-1-b-implement-event-selection-and-grouping-per-window.md
+++ b/docs/execplans/2-1-b-implement-event-selection-and-grouping-per-window.md
@@ -225,5 +225,5 @@ users' guide.
 
 ## Revision note
 
-Updated progress, discoveries, and artifacts after implementing coverage-aware
+Updated progress, discoveries, and artefacts after implementing coverage-aware
 event selection and completing validation. Remaining work: none.

--- a/docs/execplans/2-3-3-on-demand-reporting-entry-point.md
+++ b/docs/execplans/2-3-3-on-demand-reporting-entry-point.md
@@ -493,7 +493,7 @@ If tests fail:
 4. Check that `falcon.testing.TestClient` is used only in synchronous test
    functions (not inside `async def` tests).
 
-## Artifacts and notes
+## Artefacts and notes
 
 ### 200 response body
 

--- a/docs/execplans/adopt-femtologging.md
+++ b/docs/execplans/adopt-femtologging.md
@@ -265,7 +265,7 @@ Steps are re-runnable. If a stage fails, revert the affected files with
 before retrying. Re-running `uv lock`, `make fmt`, and the make-based quality
 gates is safe and should converge on a clean state.
 
-## Artifacts and Notes
+## Artefacts and Notes
 
 Expected log shape (update if the snapshot emits a different format):
 

--- a/docs/execplans/adopt-hecate.md
+++ b/docs/execplans/adopt-hecate.md
@@ -608,7 +608,7 @@ dependency, and any tests or docs that depend on the new gate. Do not remove
 the ADR unless the decision itself is reversed; supersede it with a new ADR if
 needed.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Initial planning evidence:
 

--- a/docs/execplans/local-k8s-design.md
+++ b/docs/execplans/local-k8s-design.md
@@ -202,11 +202,11 @@ The design must specify idempotence and recovery for the future scripts. It
 must state that the local script is safe to rerun, describe reuse or cleanup
 for existing clusters, and explain how to recover from failed Helm installs.
 
-## Artifacts and notes
+## Artefacts and notes
 
 The detailed Helm chart, Dockerfile, and local CLI sketches live in
 `docs/local-k8s-preview-design.md` and should be treated as the source of
-truth. This ExecPlan should only summarize the required artifacts so the design
+truth. This ExecPlan should only summarize the required artefacts so the design
 work stays centralized.
 
 - Helm chart layout plus template sketches for deployment, ingress, and

--- a/docs/execplans/task-1-5-c-define-container-image-for-preview-workloads.md
+++ b/docs/execplans/task-1-5-c-define-container-image-for-preview-workloads.md
@@ -383,7 +383,7 @@ Recovery:
 - If tests fail, check logs in `/tmp/test-*.log`.
 - To reset: `docker rmi ghillie:local` and rebuild.
 
-## Artifacts and Notes
+## Artefacts and Notes
 
 Expected file structure after completion:
 

--- a/docs/execplans/task-1-5-d-local-k3d-lifecycle-script.md
+++ b/docs/execplans/task-1-5-d-local-k3d-lifecycle-script.md
@@ -698,7 +698,7 @@ make local-k8s-down
   then `make local-k8s-up` again.
 - All Helm installs use `upgrade --install` for idempotent behaviour.
 
-## Artifacts and notes
+## Artefacts and notes
 
 ### Config dataclass (from design document)
 

--- a/docs/testing-sqlalchemy-with-pytest-and-py-pglite.md
+++ b/docs/testing-sqlalchemy-with-pytest-and-py-pglite.md
@@ -285,7 +285,7 @@ place([3](https://hoop.dev/blog/the-simplest-way-to-make-postgresql-pytest-work-
   back migrations after the tests if desired. With py-pglite, the in-memory
   database vanishes once the process ends, so explicit teardown of the schema
   is usually not required – simply let py-pglite shut down. Clean any
-  persistent artifacts (like files on disk via `work_dir` config) if they were
+  persistent artefacts (like files on disk via `work_dir` config) if they were
   created.
 
 Using Alembic in tests ensures ORM code is exercised against the **actual


### PR DESCRIPTION
## Summary

- The en-GB-oxendict spelling gate (`make spelling`, run as part of the
  required `lint-test` check) currently fails on `main`, independently
  of any feature work, because several execplan documents and a
  testing guide use the American spelling "artifact(s)" instead of
  "artefact(s)".
- This is pre-existing drift, unrelated to any in-flight change; fixing
  it here unblocks other branches that would otherwise inherit a red
  required check from `main`.

## Review walkthrough

- `docs/execplans/*.md` and `docs/testing-sqlalchemy-with-pytest-and-py-pglite.md`:
  each "Artifact(s)"/"artifact(s)" occurrence flagged by `typos` is
  corrected to "Artefact(s)"/"artefact(s)". No other content changed.

## Validation

- `make spelling` — now passes (previously failed with nine `artifact`
  → `artefact` errors).
- `make markdownlint` (via `markdownlint-cli2` on the changed files) —
  passes.
