### PR TITLE
Stop pinning the exact shared-actions SHA in the workflow contract test

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -58,6 +58,42 @@ Run all gates before committing:
 make check-fmt && make lint && make typecheck && make test && make helm-lint
 ```
 
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows, including
+calls into `leynos/shared-actions`. Contract tests that assert a caller's exact
+commit SHA create a lockstep dependency: every time Dependabot opens a bump PR,
+the test fails until a human edits the pinned constant to match. That defeats
+the purpose of automated dependency updates and turns a routine bump into a
+manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller. They
+must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Architecture checks
 
 Ghillie uses Hecate as the static architecture fitness function for Python

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -7,10 +7,16 @@ PyYAML and pin the contract it must uphold, so drift (repointing the
 pin at a branch, widening permissions, or losing the flat-layout
 configuration) fails CI on the pull request rather than surfacing in a
 scheduled or manual run.
+
+The caller must reference the correct reusable workflow at a commit
+SHA, but the SHA value itself is not asserted: Dependabot owns bumping
+it, and a lockstep exact-SHA assertion would fail every bump PR until a
+human hand-edited the pinned constant here.
 """
 
 from __future__ import annotations
 
+import re
 import typing as typ
 from pathlib import Path
 
@@ -32,12 +38,8 @@ pytestmark = pytest.mark.skipif(
     ),
 )
 
-#: The pinned commit of leynos/shared-actions providing
-#: mutation-mutmut.yml. Bump the workflow and this test together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@[0-9a-f]{40}$"
 )
 
 EXPECTED_WITH = {
@@ -74,25 +76,19 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return typ.cast("dict[str, object]", job)
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-mutmut.yml pinned to a full commit SHA.
+
+    The specific SHA value is Dependabot's to own; this only guards
+    against repointing the caller at a mutable ref such as ``main`` or
+    ``rolling``.
+    """
     uses = _mutation_job(_load()).get("uses")
     assert isinstance(uses, str), "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-mutmut.yml", (
-        f"jobs.mutation.uses must reference mutation-mutmut.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the workflow and this test together"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-mutmut.yml pinned to a "
+        f"full 40-character lowercase hex commit SHA, not a branch or tag: "
+        f"{uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

The mutation-testing caller contract test
(`tests/test_workflow_contract.py`) pinned the calling job's `uses:`
reference to an exact `leynos/shared-actions` commit SHA and asserted
equality against a hard-coded `PINNED_SHA` constant. That coupled the
test to the pin in lockstep: every Dependabot bump of the caller would
fail CI until a human hand-edited the constant, defeating the point of
automated dependency updates.

This change hands SHA ownership to Dependabot while keeping the
structural contract intact. The `uses:` assertion becomes a shape
check: the job must reference the correct reusable workflow path
(`mutation-mutmut.yml`) pinned to a full 40-character lowercase hex
commit SHA — still guarding against repointing at a mutable ref such as
`main` or `rolling` — without asserting which SHA.

## Review walkthrough

- `tests/test_workflow_contract.py`:
  - Replace `PINNED_SHA` / `EXPECTED_USES` and the exact-equality
    assertion with a compiled `USES_RE` regex
    (`^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@[0-9a-f]{40}$`)
    and match against it.
  - Rename `test_uses_reference_is_pinned_to_the_documented_sha` to
    `test_uses_reference_is_pinned_to_a_commit_sha` and update the
    module docstring: the test asserts the caller references the correct
    reusable workflow at a commit SHA, and Dependabot owns the SHA
    value.
  - Every other assertion is unchanged: least-privilege permissions,
    empty workflow-default permissions, per-ref non-cancelling
    concurrency, schedule + plain dispatch triggers, and the flat-layout
    `with:` inputs.
- `docs/developers-guide.md`: add a "Workflow pins and Dependabot"
  subsection documenting the shape-not-value policy for future contract
  tests.

The workflow files themselves are untouched; the caller keeps its
current pin and Dependabot moves it from here on. `.github/dependabot.yml`
already has the `github-actions` ecosystem entry at `directory: "/"`
that updates reusable-workflow `uses:` refs.

## Validation

- `uv run pytest tests/test_workflow_contract.py` — 6 passed against the
  current pinned SHA. The regex matches today's 40-hex value and would
  equally match any other 40-hex SHA, so a Dependabot bump no longer
  fails the test; a branch/tag ref still would.
- `ruff format --check` and `ruff check` on the test — clean.
- `markdownlint-cli2` on the developers' guide — clean.
