### PR TITLE
Add the CodeScene mode: check gate to the PR coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,6 @@ jobs:
       # generates and uploads the authoritative main-branch coverage on
       # push, so a push-triggered run of this job would otherwise generate
       # coverage twice for the same commit.
-      #
-      # Uploading to CodeScene from the PR is deferred: `mode: check`
-      # requires a gates configuration that CodeScene has not yet enabled
-      # for this project (see ddlint#287 for the model). Once
-      # coverage-main.yml has fed the project an initial upload and the
-      # gates configuration appears, add a guarded `mode: check` step here.
       - name: Generate coverage
         if: github.event_name == 'pull_request'
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
@@ -72,6 +66,18 @@ jobs:
           format: cobertura
           output-path: coverage.xml
           with-ratchet: 'true'
+
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/74419
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 
       - name: Run tests
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

- CodeScene project 74419's gates configuration is now populated
  (`GET /v2/code-coverage/projects/74419/config` returns a non-empty
  `gates` array), so the deferred `mode: check` step can land.
- Add the guarded "Check coverage against CodeScene gates" step to
  `.github/workflows/ci.yml`'s `lint-test` job, immediately after
  `Generate coverage`, pinned to the same shared-actions SHA
  (`927edd45ae77be4251a8a18ca9eb5613a2e32cbd`) already used by
  `generate-coverage`.
- Remove the deferred-gate comment the step replaces.
- `coverage-main.yml` is untouched; it stays on `mode: upload`.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/ghillie/blob/codescene-mode-check/.github/workflows/ci.yml):
  the new step runs only when `CS_ACCESS_TOKEN` is set and the event
  is `pull_request`, matching the existing `generate-coverage` guard
  shape. `format: cobertura` matches the repo's existing coverage
  format; `path` is left at the action's default (`coverage.xml`),
  which matches `generate-coverage`'s `output-path`.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes.
- No workflow-contract test asserts `ci.yml`'s coverage-step shape
  (the only contract test in the repo, `tests/test_workflow_contract.py`,
  pins `mutation-testing.yml`, which is unaffected).
- CI on this PR must show the "Check coverage against CodeScene gates"
  step executing (not skipped) and succeeding, and the `CodeScene Code
  Coverage` check completing rather than timing out, before merge.
