### PR TITLE
Bump shared-actions pins to 18bed1ca

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       # coverage twice for the same commit.
       - name: Generate coverage
         if: github.event_name == 'pull_request'
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: cobertura
           output-path: coverage.xml

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -30,7 +30,7 @@ jobs:
         uses: astral-sh/setup-uv@v8.3.0
 
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: cobertura
           output-path: coverage.xml

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
Bumps every `leynos/shared-actions` workflow and action reference to
`18bed1ca49a6de3d8882bd72635a32ae3f023d57` (current upstream main at
the time of the estate sweep).

This picks up the coverage-ratchet fix from shared-actions#353: the
baseline can now advance (cache save-key fix) and a symmetric ±1pp
dead-band absorbs coverage measurement noise. It also carries the
whitaker-installer 0.2.6 bump and the mutation-run workspace
relocation.

## Review walkthrough
Mechanical SHA substitution in `.github/workflows/` only. References
already at or beyond the fix commit are left untouched. Dependabot
retains ownership of future bumps; contract tests assert shape (path @
40-hex SHA), not the value.

## Validation
CI on this pull request exercises the bumped references directly.
