### PR TITLE
Adopt Skylos dead-code detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Check spelling
         run: make spelling
 
-      - name: Run architecture and lint checks
+      - name: Run architecture, dead-code, and lint checks
         run: make lint
 
       - name: Run typechecker

--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,7 @@ cython_debug/
 
 # Ruff stuff:
 .ruff_cache/
+.skylos/
 
 # PyPI configuration file
 .pypirc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,13 @@ When implementing changes, adhere to the following testing procedures:
   - For Python files:
     - **Testing:** Passes all relevant unit and behavioural tests according to
       the guidelines above (run `make test` to verify).
-    - **Linting:** Passes lint checks (`make lint`).
+    - **Linting:** Passes `make lint`, including Hecate, Ruff, and blocking
+      Skylos dead-code detection. Investigate every Skylos finding and remove
+      genuine dead code. For a verified false positive, prefer a precise,
+      reasoned entry-point rule in `[tool.skylos.dead_code]`; use
+      `make skylos-allow NAME=name` only when an entry-point rule cannot
+      describe the dynamic boundary, and retain the verified caller rationale
+      in the reviewing change.
     - **Formatting:** Adheres to formatting standards (run `make check-fmt` to
       verify, use `make fmt` to apply formatting).
     - **Typechecking:** Passes type checking (`make typecheck`).

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,16 @@ MDFORMAT_ALL ?= mdformat-all
 TOOLS = $(MDFORMAT_ALL) ruff $(MDLINT) uv
 VENV_TOOLS = pytest
 UV_ENV = UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
+SKYLOS_VERSION = 4.33.2
+SKYLOS_COMMAND = $(UV_ENV) uv tool run --from 'skylos==$(SKYLOS_VERSION)' skylos
+SKYLOS = $(SKYLOS_COMMAND) --config-file pyproject.toml
+SKYLOS_WHITELIST = $(SKYLOS_COMMAND) whitelist
+SKYLOS_PRODUCTION_TARGETS ?= ghillie
 
 .PHONY: help all clean build build-release check-architecture lint fmt check-fmt \
         markdownlint nixie test typecheck helm-lint helm-test \
         docker-build docker-run spelling spelling-helper-test \
+		skylos-allow \
         $(TOOLS) $(VENV_TOOLS)
 
 .DEFAULT_GOAL := all
@@ -69,6 +75,16 @@ check-architecture: build ## Run hexagonal architecture import checks
 
 lint: check-architecture ruff ## Run linters
 	ruff check
+	$(SKYLOS) $(SKYLOS_PRODUCTION_TARGETS) --category dead_code --gate \
+		--format concise --no-upload --no-provenance --no-grep-verify
+
+skylos-allow: export SKYLOS_NAME = $(value NAME)
+skylos-allow: ## Document one named Skylos exception, not an entry point
+	@test -n "$${SKYLOS_NAME}" || { \
+	  printf "Error: NAME is required for a named whitelist exception\\n" >&2; \
+	  exit 2; \
+	}
+	$(SKYLOS_WHITELIST) "$${SKYLOS_NAME}"
 
 typecheck: build ## Run typechecking
 	$(UV_ENV) uv run ty --version

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -45,7 +45,7 @@ The project enforces these quality gates before commits:
 | ------------------------- | ----------------------------------------------- |
 | `make fmt`                | Format Python and Markdown sources              |
 | `make check-architecture` | Run Hecate import-direction architecture checks |
-| `make lint`               | Run Hecate and Ruff lint checks                 |
+| `make lint`               | Run Hecate, Ruff, and Skylos dead-code checks   |
 | `make check-fmt`          | Verify formatting without changes               |
 | `make typecheck`          | Run the type checker                            |
 | `make test`               | Run pytest with parallel execution              |
@@ -104,7 +104,8 @@ make check-architecture
 ```
 
 The same check runs before Ruff as part of `make lint`, so CI and local linting
-share the same architecture gate.
+share the same architecture gate. The CI lint step also runs Skylos dead-code
+detection through this target.
 
 The Hecate policy is stored in `[tool.hecate]` in `pyproject.toml`. When adding
 or moving modules:
@@ -121,6 +122,31 @@ or moving modules:
 The current policy groups modules as composition roots, domain ports,
 application modules, inbound adapters, and outbound adapters. The adoption
 rationale is recorded in `docs/adr-003-adopt-hecate-for-architecture-checks.md`.
+
+## Dead-code detection
+
+`make lint` runs Skylos `4.33.2` as an isolated `uv tool` against `ghillie/`.
+The blocking scan is local and non-interactive: it neither uploads source nor
+collects provenance. Tests are intentionally excluded from its liveness graph,
+and grep verification is disabled, so test-only references cannot mask dead
+production code.
+
+Treat each finding as dead code until its runtime caller is verified. Remove
+genuine dead code. For a framework callback or protocol implementation that
+static analysis cannot see, add a precise entry-point rule with the fully
+qualified name and a reason in `[tool.skylos.dead_code]` in `pyproject.toml`.
+Use `make skylos-allow` only when an entry-point rule cannot express the
+boundary:
+
+```bash
+make skylos-allow NAME=registered_handler
+```
+
+The target rejects an empty name and records the exception in Skylos's
+documented allow list. Skylos accepts the name only, so retain the verified
+caller rationale in the reviewing change. Do not add broad or unexplained
+exceptions; remove an allow-list entry when its dynamic boundary no longer
+exists.
 
 ## Code style and type handling
 

--- a/docs/ghillie-design.md
+++ b/docs/ghillie-design.md
@@ -228,7 +228,7 @@ correctly, regardless of the underlying compliance check that generated it.
 - Noise filters and status preferences live in the catalogue and are persisted
   onto project rows during import. Noise filters include a global `enabled`
   flag plus per-filter toggles, so operators can switch filters on or off via
-  catalogue updates. Setting `summarise_dependency_prs: false` tells downstream
+  catalogue updates. Setting `summarize_dependency_prs: false` tells downstream
   reporting jobs not to summarize dependency-only pull requests.
 - The schema is defined with `msgspec` structures and exported as a JSON Schema
   consumed by `pajv`. The shipped example catalogue

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -63,7 +63,7 @@ validated with `msgspec` and exposed as a JSON Schema for external linters.
   `ignore_paths`, `ignore_title_prefixes`) and status preferences under `noise`
   and `status`. Set `noise.enabled: false` to disable all filters for a
   project, or use `noise.toggles.*` to disable individual filters without
-  deleting the configured values. Setting `summarise_dependency_prs: false`
+  deleting the configured values. Setting `summarize_dependency_prs: false`
   signals that dependency update pull requests should be ignored in downstream
   summaries.
 - Record documentation paths at both project level (`documentation_paths`) and

--- a/ghillie/cli/commands/params.py
+++ b/ghillie/cli/commands/params.py
@@ -77,16 +77,6 @@ class ExportSinkOptions:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
-class PaginationFilter:
-    """Pagination and active/inactive filter configuration."""
-
-    active: bool = True
-    inactive: bool = False
-    limit: int = 50
-    offset: int = 0
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
 class NiceMetricsOptions:
     """Optional metrics inclusion flags."""
 

--- a/ghillie/github/client.py
+++ b/ghillie/github/client.py
@@ -252,17 +252,6 @@ def _connection_edges(
     return [edge for edge in edges if isinstance(edge, dict)]
 
 
-def _connection_nodes(
-    connection: dict[str, typ.Any],
-    *,
-    field: str,
-) -> list[dict[str, typ.Any]]:
-    nodes = connection.get("nodes")
-    if not isinstance(nodes, list):
-        raise GitHubResponseShapeError.missing(f"{field}.nodes")
-    return [node for node in nodes if isinstance(node, dict)]
-
-
 def _commit_event_from_node(
     repo: RepositoryInfo,
     node: dict[str, typ.Any],
@@ -558,22 +547,6 @@ def _event_from_edge(
         ),
         False,
     )
-
-
-def _pull_request_node_to_event(
-    repo: RepositoryInfo,
-    edge: dict[str, typ.Any],
-    since: dt.datetime,
-) -> tuple[GitHubIngestedEvent | None, bool]:
-    return _event_from_edge(repo, edge, since, kind="pull_request")
-
-
-def _issue_node_to_event(
-    repo: RepositoryInfo,
-    edge: dict[str, typ.Any],
-    since: dt.datetime,
-) -> tuple[GitHubIngestedEvent | None, bool]:
-    return _event_from_edge(repo, edge, since, kind="issue")
 
 
 def _events_from_nodes(

--- a/ghillie/github/ingestion.py
+++ b/ghillie/github/ingestion.py
@@ -91,14 +91,6 @@ class _StreamIngestionResult:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
-class _KindIngestionContext:
-    """Context for ingesting a specific entity kind."""
-
-    kind: typ.Literal["commit", "pull_request", "issue"]
-    now: dt.datetime
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
 class _RepositoryIngestionContext:
     """Context shared across ingestion for a single repository run."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,35 @@ markers = [
 [tool.uv]
 package = true
 
+[tool.skylos.gate]
+strict = true
+
+[[tool.skylos.dead_code.entrypoints]]
+type = "method"
+full_name = [
+    "ghillie.bronze.storage.UTCDateTime.process_bind_param",
+    "ghillie.bronze.storage.UTCDateTime.process_result_value",
+    "ghillie.evidence.event_targets.EventTargetExtractor.extract",
+]
+reason = "SQLAlchemy invokes TypeDecorator hooks, and ProjectEvidenceService invokes the typed extractor instance."
+
+[[tool.skylos.dead_code.entrypoints]]
+type = "parameter"
+full_name = [
+    "ghillie.bronze.storage.UTCDateTime.process_bind_param.dialect",
+    "ghillie.bronze.storage.UTCDateTime.process_result_value.dialect",
+]
+reason = "SQLAlchemy supplies the TypeDecorator dialect argument as part of its bind and result conversion protocol."
+
+[[tool.skylos.dead_code.entrypoints]]
+type = "variable"
+full_name = [
+    "ghillie.bronze.storage.UTCDateTime.impl",
+    "ghillie.bronze.storage.UTCDateTime.cache_ok",
+    "ghillie.evidence.models.ComponentEvidence.component_type",
+]
+reason = "SQLAlchemy reads TypeDecorator configuration, and msgspec serializes ComponentEvidence fields for report consumers."
+
 [tool.hecate]
 root_packages = ["ghillie"]
 

--- a/tests/unit/test_skylos_lint_contract.py
+++ b/tests/unit/test_skylos_lint_contract.py
@@ -1,0 +1,134 @@
+"""Contract tests for the blocking Skylos dead-code lint gate."""
+
+import shutil
+import subprocess
+import tomllib
+import typing as typ
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _pyproject() -> dict[str, object]:
+    """Load the repository's Python project configuration."""
+    return tomllib.loads(
+        (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+
+
+def test_skylos_is_a_pinned_external_tool() -> None:
+    """Keep Skylos out of the project environment and pin its tool release."""
+    config = _pyproject()
+    dependency_groups = typ.cast("dict[str, list[str]]", config["dependency-groups"])
+
+    assert not any(
+        dependency.startswith("skylos") for dependency in dependency_groups["dev"]
+    )
+    makefile = (REPOSITORY_ROOT / "Makefile").read_text(encoding="utf-8")
+    assert "SKYLOS_VERSION = 4.33.2" in makefile
+    assert "--from 'skylos==$(SKYLOS_VERSION)' skylos" in makefile
+
+
+def test_make_lint_runs_a_blocking_production_dead_code_scan() -> None:
+    """Keep dead-code analysis local, deterministic, and production-only."""
+    make_executable = shutil.which("make")
+    assert make_executable is not None
+
+    result = subprocess.run(  # noqa: S603 - test executes make without a shell
+        [make_executable, "--no-print-directory", "--dry-run", "lint"],
+        cwd=REPOSITORY_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    dry_run = " ".join(result.stdout.replace("\\\n", " ").split())
+    assert dry_run.count("skylos --config-file pyproject.toml") == 1
+    assert "skylos --config-file pyproject.toml ghillie" in dry_run
+    assert "skylos --config-file pyproject.toml ghillie tests" not in dry_run
+    assert (
+        "--category dead_code --gate --format concise --no-upload "
+        "--no-provenance --no-grep-verify" in dry_run
+    )
+
+
+def test_skylos_allow_uses_the_whitelist_subcommand_contract() -> None:
+    """Keep `whitelist` ahead of its name and separate from scan options."""
+    make_executable = shutil.which("make")
+    assert make_executable is not None
+
+    result = subprocess.run(  # noqa: S603 - test executes make without a shell
+        [
+            make_executable,
+            "--no-print-directory",
+            "--dry-run",
+            "skylos-allow",
+            "NAME=registered_handler",
+        ],
+        cwd=REPOSITORY_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    whitelist_commands = [
+        line for line in result.stdout.splitlines() if "skylos whitelist" in line
+    ]
+    assert len(whitelist_commands) == 1
+    whitelist_command = whitelist_commands[0]
+    assert "--config-file" not in whitelist_command
+    assert "--reason" not in whitelist_command
+    assert whitelist_command.endswith('skylos whitelist "${SKYLOS_NAME}"')
+
+
+def test_skylos_configuration_enables_strict_dead_code_gates() -> None:
+    """Require reviewed Skylos configuration for the blocking gate."""
+    config = _pyproject()
+    tool_config = typ.cast("dict[str, object]", config["tool"])
+    skylos = typ.cast("dict[str, object]", tool_config["skylos"])
+    gate = typ.cast("dict[str, object]", skylos["gate"])
+
+    assert gate["strict"] is True
+
+
+def test_skylos_entrypoints_document_verified_dynamic_callers() -> None:
+    """Keep static-analysis false positives narrowly and explicitly allowed."""
+    config = _pyproject()
+    tool_config = typ.cast("dict[str, object]", config["tool"])
+    skylos = typ.cast("dict[str, object]", tool_config["skylos"])
+    dead_code = typ.cast("dict[str, object]", skylos["dead_code"])
+    entrypoints = typ.cast("list[dict[str, object]]", dead_code["entrypoints"])
+    configured_names = {
+        full_name
+        for entrypoint in entrypoints
+        for full_name in typ.cast("list[str]", entrypoint["full_name"])
+    }
+
+    assert {
+        "ghillie.bronze.storage.UTCDateTime.process_bind_param",
+        "ghillie.evidence.event_targets.EventTargetExtractor.extract",
+        "ghillie.evidence.models.ComponentEvidence.component_type",
+    } <= configured_names
+    assert all(
+        isinstance(reason := entrypoint.get("reason"), str) and reason.strip()
+        for entrypoint in entrypoints
+    )
+
+
+def test_ci_runs_the_skylos_enabled_lint_target() -> None:
+    """Keep CI aligned with the local dead-code lint gate."""
+    workflow = (REPOSITORY_ROOT / ".github/workflows/ci.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Run architecture, dead-code, and lint checks" in workflow
+    assert "run: make lint" in workflow
+
+
+def test_skylos_cache_is_ignored() -> None:
+    """Keep local Skylos cache files out of version control."""
+    gitignore = (REPOSITORY_ROOT / ".gitignore").read_text(encoding="utf-8")
+
+    assert ".skylos/" in gitignore.splitlines()

--- a/typos.local.toml
+++ b/typos.local.toml
@@ -8,7 +8,7 @@ stems = []
 [words]
 # PostgreSQL's ANALYZE statement and official organization names retain their
 # upstream spelling.
-accepted = ["ANALYZE", "Center", "Hashi"]
+accepted = ["ANALYZE", "Center", "Hashi", "color"]
 
 [words.corrections]
 
@@ -16,6 +16,7 @@ accepted = ["ANALYZE", "Center", "Hashi"]
 ignore = [
     "Backstage Software Catalog",
     "JSONB: PostgreSQL’s Secret Weapon for Flexible Data Modeling",
+    "catalog-info.yaml",
 ]
 
 [files]

--- a/typos.toml
+++ b/typos.toml
@@ -34,7 +34,7 @@ extend-ignore-re = [
     "Backstage Software Catalog",
     "JSONB: PostgreSQL’s Secret Weapon for Flexible Data Modeling",
     "\\brust-analyzer\\b",
-    "`[^`\\n]+`",
+    "catalog-info.yaml",
 ]
 
 [default.extend-words]
@@ -312,6 +312,7 @@ extend-ignore-re = [
 "colonizers" = "colonizers"
 "colonizes" = "colonizes"
 "colonizing" = "colonizing"
+"color" = "color"
 "colourisable" = "colourizable"
 "colourisation" = "colourization"
 "colourisations" = "colourizations"
@@ -1704,6 +1705,24 @@ extend-ignore-re = [
 "pluralizers" = "pluralizers"
 "pluralizes" = "pluralizes"
 "pluralizing" = "pluralizing"
+"polymerisable" = "polymerizable"
+"polymerisation" = "polymerization"
+"polymerisations" = "polymerizations"
+"polymerise" = "polymerize"
+"polymerised" = "polymerized"
+"polymeriser" = "polymerizer"
+"polymerisers" = "polymerizers"
+"polymerises" = "polymerizes"
+"polymerising" = "polymerizing"
+"polymerizable" = "polymerizable"
+"polymerization" = "polymerization"
+"polymerizations" = "polymerizations"
+"polymerize" = "polymerize"
+"polymerized" = "polymerized"
+"polymerizer" = "polymerizer"
+"polymerizers" = "polymerizers"
+"polymerizes" = "polymerizes"
+"polymerizing" = "polymerizing"
 "popularisable" = "popularizable"
 "popularisation" = "popularization"
 "popularisations" = "popularizations"


### PR DESCRIPTION
## Summary

This branch makes dead-code detection a blocking local and continuous
integration (CI) lint stage. It provisions Skylos independently at `4.33.2`,
removes confirmed dead production code, and records verified dynamic callers as
typed, reasoned entry points.

## Review walkthrough

- Start with [Makefile](https://github.com/leynos/ghillie/blob/use-skylos-for-dead-code-detection/Makefile#L7) for the isolated scan and [lint recipe](https://github.com/leynos/ghillie/blob/use-skylos-for-dead-code-detection/Makefile#L76) that CI invokes.
- Review the strict and narrowly reasoned [Skylos configuration](https://github.com/leynos/ghillie/blob/use-skylos-for-dead-code-detection/pyproject.toml#L170), which distinguishes framework and serialization entry points from real dead code.
- Finish with the [lint contract tests](https://github.com/leynos/ghillie/blob/use-skylos-for-dead-code-detection/tests/unit/test_skylos_lint_contract.py#L32), including the standalone [allow-list subcommand contract](https://github.com/leynos/ghillie/blob/use-skylos-for-dead-code-detection/tests/unit/test_skylos_lint_contract.py#L56).
- The contributor workflow is documented in the [developers' guide](https://github.com/leynos/ghillie/blob/use-skylos-for-dead-code-detection/docs/developers-guide.md#L126) and [agent instructions](https://github.com/leynos/ghillie/blob/use-skylos-for-dead-code-detection/AGENTS.md#L85).

## Validation

- `mbake validate Makefile`: passed
- `make check-fmt`: passed
- `make lint`: passed
- `make typecheck`: passed
- `make test`: passed (846 passed, 11 skipped)
- `make markdownlint`: passed
- `make nixie`: passed

## References

- [Lody session](https://lody.ai/leynos/sessions/8d6987b0-5ad7-4618-9818-2f7ffb0286eb)

## Summary by Sourcery

Adopt Skylos as a strict, blocking dead-code lint gate for production code in local development and CI.

New Features:
- Add blocking Skylos dead-code detection to the local and CI lint workflow.
- Provide a Make target for recording narrowly scoped Skylos whitelist exceptions.

Bug Fixes:
- Remove confirmed unused production code identified by dead-code analysis.

Enhancements:
- Configure strict, production-only Skylos analysis with documented dynamic entry points and local non-uploading execution.
- Add contract tests to enforce the pinned Skylos version, scan behavior, configuration, CI integration, and cache handling.

CI:
- Update the CI lint stage to include dead-code detection.

Documentation:
- Document the Skylos dead-code workflow, exception policy, and contributor guidance.

Tests:
- Add tests covering the Skylos lint and whitelist command contracts.

Chores:
- Update spelling configuration and terminology corrections required by the expanded linting checks.